### PR TITLE
simplify coin class name handling

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1796,7 +1796,7 @@ class ElectrumWindow(QMainWindow):
             server_trust = chainkey.chainparams.get_server_trust(ch.code)
             uses_pow = server_trust['pow']
             num_servers = server_trust['servers']
-            item = QTreeWidgetItem([ch.code, ch.class_name, y_or_n(uses_pow), str(num_servers)])
+            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(uses_pow), str(num_servers)])
             chains_view.addTopLevelItem(item)
         chains_view.setCurrentItem(chains_view.topLevelItem(0))
         main_layout.addWidget(chains_view)

--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -7,29 +7,29 @@ import chains
 #   chain_index: The index (BIP-0044) used in child key derivation
 #       This is just for organization, the class of the actual
 #       cryptocur has the chain index as well.
+#   coin_name: Full name of the cryptocurrency
 #   code: Abbreviated form of the cryptocurrency
 #   module_name: Name of the module containing specifics on the cryptocur
-#   class_name: Name of the class implementing the cryptocur
 
 active_chain = None
 
-ChainParams = namedtuple('ChainParams', ('chain_index', 'code', 'module_name', 'class_name'))
+ChainParams = namedtuple('ChainParams', ('chain_index', 'coin_name', 'code', 'module_name'))
 
 _known_chains = (
     # Bitcoin
-    ChainParams(0, 'BTC', 'bitcoin', 'Bitcoin'),
+    ChainParams(0, 'Bitcoin', 'BTC', 'bitcoin'),
 
     # Litecoin
-    ChainParams(2, 'LTC', 'litecoin', 'Litecoin'),
+    ChainParams(2, 'Litecoin', 'LTC', 'litecoin'),
 
     # Darkcoin
-    ChainParams(5, 'DRK', 'darkcoin', 'Darkcoin'),
+    ChainParams(5, 'Darkcoin', 'DRK', 'darkcoin'),
     
     # Mazacoin
-    ChainParams(13, 'MZC', 'mazacoin', 'Mazacoin'),
+    ChainParams(13, 'Mazacoin', 'MZC', 'mazacoin'),
 
     # Viacoin
-    ChainParams(14, 'VIA', 'viacoin', 'Viacoin'),
+    ChainParams(14, 'Viacoin', 'VIA', 'viacoin'),
 )
 
 _known_chain_dict = dict((i.code, i) for i in _known_chains)
@@ -92,5 +92,5 @@ def get_chain_instance(code):
     params = get_params(code)
     module_name = params.module_name
     classmodule = importlib.import_module(''.join(['chainkey.chains.', module_name]))
-    classInst = getattr(classmodule, params.class_name)
+    classInst = getattr(classmodule, 'Currency')
     return classInst()

--- a/lib/chains/README.md
+++ b/lib/chains/README.md
@@ -35,9 +35,11 @@ In addition to those constants, some more modular information is required, inclu
 
 Also, the number of headers in one chunk is stored in the `chunk_size` variable. This is 2016 in Electrum.
 
+Lastly, after the currency class definition, it is required to define a variable called `Currency` as the currency's class name. For example, `Currency = Bitcoin` in bitcoin.py, where the class name is "Bitcoin."
+
 ### Functions
 
-All functions for verifying headers are required in a chainkey module. Most importantly, `get_target()`, `verify_chain()`, and `verify_chunk()`, but also any functions they rely on, including `set_headers_path()`, `path()`, `header_to_string()`, `header_from_string()`, `hash_header()`, `save_chunk()`, `save_header()`, and `read_header()`.
+All functions for verifying headers are required in a chainkey module. Most importantly, `get_target()`, `verify_chain()`, and `verify_chunk()`, but also any functions they rely on, including `header_to_string()`, `header_from_string()`, `hash_header()`, `save_chunk()`, `save_header()`, and `read_header()`.
 
 Note that commonly in Electrum forks, the functions `save_chunk()` and `save_header()` make a call to a function `set_local_height()`. This call must be removed in the chainkey module, as `set_local_height()` is called elsewhere. Also note that any calls to `print_error()` may be removed, as importing that function is not required.
 

--- a/lib/chains/bitcoin.py
+++ b/lib/chains/bitcoin.py
@@ -53,14 +53,6 @@ class Bitcoin(CryptoCur):
         'us.electrum.be':DEFAULT_PORTS,
     }
 
-
-
-    def set_headers_path(self, path):
-        self.headers_path = path
-
-    def path(self):
-        return self.headers_path
-
     def verify_chain(self, chain):
 
         first_header = chain[0]
@@ -213,3 +205,4 @@ class Bitcoin(CryptoCur):
         new_bits = c + MM * i
         return new_bits, new_target
 
+Currency = Bitcoin

--- a/lib/chains/darkcoin.py
+++ b/lib/chains/darkcoin.py
@@ -6,6 +6,7 @@ import darkcoin_hash as darkhash
 HashX11 = lambda x: darkhash.getPoWHash(x)
 
 class Darkcoin(CryptoCur):
+    PoW = False
     chain_index = 5
     coin_name = 'Darkcoin'
     code = 'DRK'
@@ -42,12 +43,6 @@ class Darkcoin(CryptoCur):
         'drk1.electrum-servers.us':DEFAULT_PORTS,
         '103.13.228.168':DEFAULT_PORTS,
     }
-
-    def set_headers_path(self, path):
-        self.headers_path = path
-
-    def path(self):
-        return self.headers_path
 
     def verify_chain(self, chain):
 
@@ -203,3 +198,4 @@ class Darkcoin(CryptoCur):
         new_bits = c + MM * i
         return new_bits, new_target
 
+Currency = Darkcoin

--- a/lib/chains/litecoin.py
+++ b/lib/chains/litecoin.py
@@ -49,12 +49,6 @@ class Litecoin(CryptoCur):
         'rho.hicapacity.org': DEFAULT_PORTS,
     }
 
-    def set_headers_path(self, path):
-        self.headers_path = path
-
-    def path(self):
-        return self.headers_path
-
     def verify_chain(self, chain):
 
         first_header = chain[0]
@@ -209,3 +203,4 @@ class Litecoin(CryptoCur):
         new_bits = c + MM * i
         return new_bits, new_target
 
+Currency = Litecoin

--- a/lib/chains/mazacoin.py
+++ b/lib/chains/mazacoin.py
@@ -37,12 +37,6 @@ class Mazacoin(CryptoCur):
         'tate.cryptoadhd.com':DEFAULT_PORTS,
     }
 
-    def set_headers_path(self, path):
-        self.headers_path = path
-
-    def path(self):
-        return self.headers_path
-
     # Used on chain reorg
     def reorg_handler(self, local_height):
         name = self.path()
@@ -338,3 +332,4 @@ class Mazacoin(CryptoCur):
 
         return self.get_target_dgw3(block_height, chain)
 
+Currency = Mazacoin

--- a/lib/chains/viacoin.py
+++ b/lib/chains/viacoin.py
@@ -12,7 +12,6 @@ try:
 except ImportError:
     from scrypt import scrypt_1024_1_1_80 as getPoWHash
 
-
 class Viacoin(CryptoCur):
     PoW = False
     chain_index = 14
@@ -48,12 +47,6 @@ class Viacoin(CryptoCur):
         'server.vialectrum.org': DEFAULT_PORTS,
         'vialectrum.viacoin.net': DEFAULT_PORTS,
     }
-
-    def set_headers_path(self, path):
-        self.headers_path = path
-
-    def path(self):
-        return self.headers_path
 
     def verify_chain(self, chain):
 
@@ -211,3 +204,4 @@ class Viacoin(CryptoCur):
         return new_bits, new_target
 
 
+Currency = Viacoin

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -115,6 +115,37 @@ class SimpleConfig(object):
             out = self.user_config.get('active_chain_code', default)
         return out
 
+    def get_above_chain(self, key, default = None):
+        out = None
+        with self.lock:
+            out = self.read_only_options.get(key)
+            if not out:
+                try:
+                    out = self.user_config.get(key, default)
+                except KeyError:
+                    out = None
+        return out
+
+    def set_key_above_chain(self, key, value, save=True):
+        if not self.is_modifiable(key):
+            print "Warning: not changing key '%s' because it is not modifiable" \
+                  " (passed as command line option or defined in /etc/encompass.conf)"%key
+        with self.lock:
+            self.user_config[key] = value
+            if save:
+                self.save_user_config()
+        return
+
+    def get_chain_config(self, chaincode):
+        '''Convenience method for getting a chain's config dict'''
+        return self.get_above_chain(chaincode)
+
+    def set_chain_config(self, chaincode, value):
+        '''Convenience method for setting a chain's config dict'''
+        if not chainparams.is_known_chain(chaincode):
+            return False
+        return self.set_key_above_chain(chaincode, value)
+
     def set_key(self, key, value, save = True):
         if not self.is_modifiable(key):
             print "Warning: not changing key '%s' because it is not modifiable" \

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -125,6 +125,15 @@ class WalletStorage(object):
                 v = copy.deepcopy(v)
             return v
 
+    def get_chain_value(self, code, key, default=None):
+        """Shortcut for getting info within a certain chain"""
+        try:
+            chain = self.get_above_chain(code)
+            data = chain.get(key)
+        except:
+            data = None
+        return data
+
     def get(self, key, default=None):
         try:
             active_chain_code = self.config.get_active_chain_code()


### PR DESCRIPTION
- Removes the need for specifying a coin's class name in chainparams. 
- Removes redundant method definitions in coin classes ( set_headers_path() and path() ).
