### PR TITLE
store wallet_type above chain

### DIFF
--- a/gui/qt/installwizard.py
+++ b/gui/qt/installwizard.py
@@ -368,7 +368,7 @@ class InstallWizard(QDialog):
                 wallet_type = '2fa'
 
             if action == 'create':
-                self.storage.put('wallet_type', wallet_type, False)
+                self.storage.put_above_chain('wallet_type', wallet_type, False)
 
         if action is None:
             return
@@ -569,7 +569,7 @@ class InstallWizard(QDialog):
                 wallet.create_main_account(password)
 
             else:
-                self.storage.put('wallet_type', t)
+                self.storage.put_above_chain('wallet_type', t)
                 wallet = run_hook('installwizard_restore', self, self.storage)
                 if not wallet:
                     return

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -235,8 +235,10 @@ class Abstract_Wallet(object):
             self.update_tx_outputs(tx_hash)
 
         # save wallet type the first time
-        if self.storage.get('wallet_type') is None:
-            self.storage.put('wallet_type', self.wallet_type, True)
+        if self.storage.get_above_chain('wallet_type') is None:
+            self.storage.put_above_chain('wallet_type', self.wallet_type, True)
+        #if self.storage.get('wallet_type') is None:
+        #    self.storage.put('wallet_type', self.wallet_type, True)
 
     def set_chain(self, chaincode):
         result = self.storage.config.set_active_chain_code(chaincode)
@@ -1708,7 +1710,10 @@ class Wallet(object):
             sys.exit(1)
 
         run_hook('add_wallet_types', wallet_types)
-        wallet_type = storage.get('wallet_type')
+        wallet_type = storage.get_above_chain('wallet_type')
+        # If wallet_type isn't above chain, get it from where it used to be
+        if wallet_type is None:
+            wallet_type = storage.get('wallet_type')
         if wallet_type:
             for cat, t, name, c in wallet_types:
                 if t == wallet_type:


### PR DESCRIPTION
Store `wallet_type` above chain, with backwards-compatibility for wallets before this update.
