### PR TITLE
add option to open the last wallet on startup

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -234,6 +234,10 @@ class ElectrumWindow(QMainWindow):
 
         self.clear_receive_tab()
         self.update_receive_tab()
+
+        use_default_wallet = self.config.get_above_chain('use_default_wallet', True)
+        if use_default_wallet == False:
+            self.config.set_key_above_chain('current_wallet', os.path.basename(self.wallet.storage.path))
         run_hook('load_wallet', wallet)
 
 
@@ -2772,6 +2776,12 @@ class ElectrumWindow(QMainWindow):
         can_edit_fees_cb.stateChanged.connect(on_editfees)
         can_edit_fees_help = HelpButton(_('This option lets you edit fees in the send tab.'))
         widgets.append((can_edit_fees_cb, None, can_edit_fees_help))
+
+        use_def_wallet_cb = QCheckBox(_('Open default_wallet on wallet start'))
+        use_def_wallet_cb.setChecked(self.config.get_above_chain('use_default_wallet', True))
+        use_def_wallet_cb.stateChanged.connect(lambda x: self.config.set_key_above_chain('use_default_wallet', use_def_wallet_cb.isChecked()))
+        use_def_wallet_help = HelpButton(_('Open default_wallet when Encompass starts. Otherwise, open the last wallet that was open.'))
+        widgets.append((use_def_wallet_cb, None, use_def_wallet_help))
 
         for a,b,c in widgets:
             i = grid.rowCount()

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -83,7 +83,11 @@ class WalletStorage(object):
         if not os.path.exists(dirpath):
             os.mkdir(dirpath)
 
-        new_path = os.path.join(config.path, "wallets", "default_wallet")
+        if config.get_above_chain('use_default_wallet', True):
+            current_wallet = 'default_wallet'
+        else:
+            current_wallet = config.get_above_chain('current_wallet', 'default_wallet')
+        new_path = os.path.join(config.path, "wallets", current_wallet)
 
         # default path in pre 1.9 versions
         old_path = os.path.join(config.path, "electrum.dat")


### PR DESCRIPTION
Add an option to open the last wallet that was open when the wallet starts up. By default, the "default_wallet" file will be opened, as is current behavior.
