### PR TITLE
Backwards-compatible DRK->DASH

### DIFF
--- a/encompass
+++ b/encompass
@@ -180,6 +180,10 @@ if __name__ == '__main__':
     if config.get_active_chain_code() is None:
         config.set_active_chain_code('mzc')
 
+    # Backwards-compatible Darkcoin->Dash rebrand
+    if config.get_active_chain_code() == 'DRK':
+        config.set_active_chain_code('DASH')
+
     # URI scheme for active chain
     uri_scheme = ''.join(['^', chainparams.get_active_chain().coin_name.lower(), ':'])
     if len(args) == 0:

--- a/lib/chains/__init__.py
+++ b/lib/chains/__init__.py
@@ -4,5 +4,5 @@ import ltc_scrypt
 import scrypt
 import litecoin
 import viacoin
-import darkcoin
+import dash
 #__all__ = ['cryptocur, bitcoin, mazacoin']

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'chainkey.chains.scrypt',
         'chainkey.chains.litecoin',
         'chainkey.chains.viacoin',
-        'chainkey.chains.darkcoin',        
+        'chainkey.chains.dash',
         'chainkey_gui.gtk',
         'chainkey_gui.qt.__init__',
         'chainkey_gui.qt.amountedit',


### PR DESCRIPTION
Makes the DASH rebrand backwards-compatible.
**To be used in conjunction with https://github.com/mazaclub/encompass/pull/41**
