### PR TITLE
use chain-specific WIF version bytes

### DIFF
--- a/lib/account.py
+++ b/lib/account.py
@@ -146,7 +146,9 @@ class ImportedAccount(Account):
         address = self.get_addresses(0)[i]
         pk = pw_decode(self.keypairs[address][1], password)
         # this checks the password
-        assert address == address_from_private_key(pk)
+        assert address == address_from_private_key(pk,
+            addrtype = self.active_chain.p2pkh_version, 
+            wif_version = self.active_chain.wif_version)
         return [pk]
 
     def has_change(self):
@@ -332,7 +334,7 @@ class BIP32_Account(Account):
             if not xpriv:
                 continue
             _, _, _, c, k = deserialize_xkey(xpriv)
-            pk = bip32_private_key( sequence, k, c )
+            pk = bip32_private_key( sequence, k, c, self.active_chain.wif_version )
             out.append(pk)
         return out
 

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -371,7 +371,7 @@ def public_key_from_private_key(sec, addrtype=128):
     return public_key.encode('hex')
 
 
-def address_from_private_key(sec, addrtype=0, wif_verison=128):
+def address_from_private_key(sec, addrtype=0, wif_version=128):
     public_key = public_key_from_private_key(sec, wif_version)
     address = public_key_to_bc_address(public_key.decode('hex'), addrtype)
     return address

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -325,20 +325,20 @@ def PrivKeyToSecret(privkey):
     return privkey[9:9+32]
 
 
-def SecretToASecret(secret, compressed=False, addrtype=0):
-    vchIn = chr((addrtype+128)&255) + secret
+def SecretToASecret(secret, compressed=False, addrtype=128):
+    vchIn = chr(addrtype) + secret
     if compressed: vchIn += '\01'
     return EncodeBase58Check(vchIn)
 
-def ASecretToSecret(key, addrtype=0):
+def ASecretToSecret(key, addrtype=128):
     vch = DecodeBase58Check(key)
-    if vch and vch[0] == chr((addrtype+128)&255):
+    if vch and vch[0] == chr(addrtype):
         return vch[1:]
     else:
         return False
 
-def regenerate_key(sec):
-    b = ASecretToSecret(sec)
+def regenerate_key(sec, addrtype=128):
+    b = ASecretToSecret(sec, addrtype)
     if not b:
         return False
     b = b[0:32]
@@ -357,23 +357,23 @@ def GetSecret(pkey):
     return ('%064x' % pkey.secret).decode('hex')
 
 
-def is_compressed(sec):
-    b = ASecretToSecret(sec)
+def is_compressed(sec, addrtype=128):
+    b = ASecretToSecret(sec, addrtype)
     return len(b) == 33
 
 
-def public_key_from_private_key(sec):
+def public_key_from_private_key(sec, addrtype=128):
     # rebuild public key from private key, compressed or uncompressed
-    pkey = regenerate_key(sec)
+    pkey = regenerate_key(sec, addrtype)
     assert pkey
-    compressed = is_compressed(sec)
+    compressed = is_compressed(sec, addrtype)
     public_key = GetPubKey(pkey.pubkey, compressed)
     return public_key.encode('hex')
 
 
-def address_from_private_key(sec, addrtype=0):
-    public_key = public_key_from_private_key(sec)
-    address = public_key_to_bc_address(public_key.decode('hex'))
+def address_from_private_key(sec, addrtype=0, wif_verison=128):
+    public_key = public_key_from_private_key(sec, wif_version)
+    address = public_key_to_bc_address(public_key.decode('hex'), addrtype)
     return address
 
 
@@ -391,9 +391,9 @@ def is_address(addr):
     return addr == hash_160_to_bc_address(h, addrtype)
 
 
-def is_private_key(key):
+def is_private_key(key, addrtype=128):
     try:
-        k = ASecretToSecret(key)
+        k = ASecretToSecret(key, addrtype)
         return k is not False
     except:
         return False
@@ -787,7 +787,7 @@ def bip32_public_derivation(xpub, branch, sequence, testnet=False):
     return EncodeBase58Check(xpub)
 
 
-def bip32_private_key(sequence, k, chain):
+def bip32_private_key(sequence, k, chain, addrtype=128):
     for i in sequence:
         k, chain = CKD_priv(k, chain, i)
-    return SecretToASecret(k, True)
+    return SecretToASecret(k, True, addrtype)

--- a/lib/tests/test_chains_base58.py
+++ b/lib/tests/test_chains_base58.py
@@ -1,0 +1,32 @@
+import unittest
+from lib import bitcoin
+from lib import chainparams
+
+class ChainsBase58Test(unittest.TestCase):
+
+    def setUp(self):
+        super(ChainsBase58Test, self).setUp()
+        chainparams.set_active_chain('BTC')
+
+class TestChainsBase58(ChainsBase58Test):
+
+    def setUp(self):
+        super(TestChainsBase58, self).setUp()
+        self.masterkey = 'xprv9s21ZrQH143K2AyWpResEyFfXb4J8BDDjUfG9WH7Q199E91HvHnPMM33yxLBFMcDe61QKRZvAiVLWLhxnRQg9pvGPvK7Acca3V9CZ21KSY9'
+        self.privkey = bitcoin.deserialize_xkey(self.masterkey)[4]
+
+    def test_wif_encoding(self):
+        active_chain = chainparams.get_active_chain()
+        wif = bitcoin.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
+        self.assertEqual('L3PoHZXjsvP91C8WuyiwzYKgjzthZD2Q39Wzrwfsndov6Cwcu8zX', wif)
+
+        addr = bitcoin.address_from_private_key(wif, addrtype = active_chain.p2pkh_version, wif_version = active_chain.wif_version)
+        self.assertEqual('1599aBMAHbgEkf4dzvd9jxBFgVyufZVVc1', addr)
+
+        chainparams.set_active_chain('MZC')
+        active_chain = chainparams.get_active_chain()
+        wif = bitcoin.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
+        self.assertEqual('aF4LB486ggLLYsQG1FcgRFQSdiBKhP4BfZKWaYvxvaAF7z6MGkAG', wif)
+
+        addr = bitcoin.address_from_private_key(wif, addrtype = active_chain.p2pkh_version, wif_version = active_chain.wif_version)
+        self.assertEqual('MC3JocFZncr3eL2yDuH5zDnb9is5GUzUJv', addr)

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -532,8 +532,9 @@ class Transaction:
     def sweep(klass, privkeys, network, to_address, fee):
         inputs = []
         for privkey in privkeys:
-            pubkey = public_key_from_private_key(privkey)
-            address = address_from_private_key(privkey)
+            pubkey = public_key_from_private_key(privkey, chainparams.get_active_chain().wif_version)
+            address = address_from_private_key(privkey,
+                chainparams.get_active_chain().p2pkh_version, chainparams.get_active_chain().wif_version)
             u = network.synchronous_get([ ('blockchain.address.listunspent',[address])])[0]
             pay_script = klass.pay_script('address', address)
             for item in u:
@@ -750,13 +751,13 @@ class Transaction:
                     x_pubkeys = txin['x_pubkeys']
                     ii = x_pubkeys.index(x_pubkey)
                     sec = keypairs[x_pubkey]
-                    pubkey = public_key_from_private_key(sec)
+                    pubkey = public_key_from_private_key(sec, self.chain.wif_version)
                     txin['x_pubkeys'][ii] = pubkey
                     txin['pubkeys'][ii] = pubkey
                     self.inputs[i] = txin
                     # add signature
                     for_sig = Hash(self.tx_for_sig(i).decode('hex'))
-                    pkey = regenerate_key(sec)
+                    pkey = regenerate_key(sec, self.chain.wif_version)
                     secexp = pkey.secret
                     private_key = ecdsa.SigningKey.from_secret_exponent( secexp, curve = SECP256k1 )
                     public_key = private_key.get_verifying_key()

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -291,7 +291,7 @@ class Abstract_Wallet(object):
     def convert_imported_keys(self, password):
         for k, v in self.imported_keys.items():
             sec = pw_decode(v, password)
-            pubkey = public_key_from_private_key(sec)
+            pubkey = public_key_from_private_key(sec, self.active_chain.wif_version)
             address = public_key_to_bc_address(pubkey.decode('hex'))
             assert address == k
             self.import_key(sec, password)
@@ -349,7 +349,7 @@ class Abstract_Wallet(object):
 
     def import_key(self, sec, password):
         try:
-            pubkey = public_key_from_private_key(sec)
+            pubkey = public_key_from_private_key(sec, self.active_chain.wif_version)
             address = public_key_to_bc_address(pubkey.decode('hex'))
         except Exception:
             raise Exception('Invalid private key')
@@ -430,7 +430,7 @@ class Abstract_Wallet(object):
         keys = self.get_private_key(address, password)
         assert len(keys) == 1
         sec = keys[0]
-        key = regenerate_key(sec)
+        key = regenerate_key(sec, self.active_chain.wif_version)
         compressed = is_compressed(sec)
         return key.sign_message(message, compressed, address)
 
@@ -438,7 +438,7 @@ class Abstract_Wallet(object):
         address = public_key_to_bc_address(pubkey.decode('hex'), self.active_chain.p2pkh_version)
         keys = self.get_private_key(address, password)
         secret = keys[0]
-        ec = regenerate_key(secret)
+        ec = regenerate_key(secret, self.active_chain.wif_version)
         decrypted = ec.decrypt_message(message)
         return decrypted
 
@@ -1790,7 +1790,7 @@ class Wallet(object):
         if not text:
             return False
         for x in text.split():
-            if not bitcoin.is_private_key(x):
+            if not bitcoin.is_private_key(x, chainparams.get_active_chain().wif_version):
                 return False
         return True
 


### PR DESCRIPTION
When encoding a private key in WIF for the user to export/etc., use the chain-specific WIF version byte.
