### PR TITLE
do not include next_account address in wallet.addresses()

### DIFF
--- a/lib/tests/test_wallet.py
+++ b/lib/tests/test_wallet.py
@@ -154,7 +154,7 @@ class TestNewWallet(WalletTestCase):
 
         # Importing a key works.
         self.wallet.import_key(self.import_private_key, "")
-        self.assertEqual(2, len(self.wallet.addresses()))
+        self.assertEqual(1, len(self.wallet.addresses()))
         self.assertIn(self.import_key_address, self.wallet.addresses())
 
         self.assertTrue(self.wallet.has_imported_keys())
@@ -162,7 +162,7 @@ class TestNewWallet(WalletTestCase):
         # Deleting the key works.
         self.wallet.delete_imported_key(self.import_key_address)
         self.assertFalse(self.wallet.has_imported_keys())
-        self.assertEqual(1, len(self.wallet.addresses()))
+        self.assertEqual(0, len(self.wallet.addresses()))
         self.assertNotIn(self.import_key_address, self.wallet.addresses())
 
     def test_update_password(self):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -1438,10 +1438,10 @@ class BIP32_HD_Wallet(BIP32_Wallet):
 
     def addresses(self, b=True):
         l = BIP32_Wallet.addresses(self, b)
-        if self.next_account:
-            next_address = self.next_account[2]
-            if next_address not in l:
-                l.append(next_address)
+#        if self.next_account:
+#            _, _, next_address = self.next_account
+#            if next_address not in l:
+#                l.append(next_address)
         return l
 
     def get_address_index(self, address):


### PR DESCRIPTION
This fixes an issue in displaying a wallet's private keys.
