### PR TITLE
multisig - use active chain wif version

### DIFF
--- a/lib/account.py
+++ b/lib/account.py
@@ -422,7 +422,7 @@ class BIP32_Account_2of2(BIP32_Account):
 
         xpriv = wallet.get_master_private_key("x1/", password)
         _, _, _, c, k = deserialize_xkey(xpriv)
-        pk = bip32_private_key( sequence, k, c )
+        pk = bip32_private_key( sequence, k, c, addrtype=self.active_chain.wif_version )
         out.append(pk)
 
         return out


### PR DESCRIPTION
Fix an issue in which accounts return a Bitcoin WIF when asked for a private key, rather than the key formatted with the active chain's WIF version.
