### PR TITLE
fix private key retrieval in multisig wallets

### DIFF
--- a/lib/account.py
+++ b/lib/account.py
@@ -409,7 +409,11 @@ class BIP32_Account_2of2(BIP32_Account):
     def get_private_key(self, sequence, wallet, password):
         out = []
         if len(sequence) == 2:
-            sequence.insert(0, self.active_chain.chain_index)
+            # if sequence is a tuple, add the chain index to it as a tuple
+            if isinstance(sequence, tuple):
+                sequence = (self.active_chain.chain_index, ) + sequence
+            else:
+                sequence.insert(0, self.active_chain.chain_index)
 #        xpubs = self.get_master_pubkeys()
 #        roots = [k for k, v in wallet.master_public_keys.iteritems() if v in xpubs]
 #        for root in roots:


### PR DESCRIPTION
Fix a bug in which the wallet tries to prepend a the active chain index to a tuple.

To test:
Create a multisig (2-of-2 or 2-of-3) wallet. Right-click an address in the 'Addresses' tab. Click 'Private key'. You should see the private key that your wallet knows in WIF.
