### PR TITLE
set default active chain if the active chain in config is not present

### DIFF
--- a/encompass
+++ b/encompass
@@ -221,6 +221,10 @@ if __name__ == '__main__':
     if config.get_active_chain_code() == 'DRK':
         config.set_active_chain_code('DASH')
 
+    # if the last active chain is no longer present, default to mzc
+    if not chainparams.is_known_chain(config.get_active_chain_code()):
+        config.set_active_chain_code('mzc')
+
     # URI scheme for active chain
     uri_scheme = ''.join(['^', chainparams.get_active_chain().coin_name.lower(), ':'])
     if len(args) == 0:


### PR DESCRIPTION
If for some reason the chain that was active when Encompass shut down is no longer present, set the active chain to MZC instead of failing to start and requiring manual editing of the config.

This helps a lot when switching between branches that contain their own chainkey modules.
