### PR TITLE
Implement Blackcoin; use canonical DER signature encoding

### DIFF
--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -30,6 +30,9 @@ _known_chains = (
 
     # Peercoin
     ChainParams(6, 'Peercoin', 'PPC', 'peercoin'),
+
+    # Blackcoin
+    ChainParams(10, 'Blackcoin', 'BLK', 'blackcoin'),
     
     # Mazacoin
     ChainParams(13, 'Mazacoin', 'MZC', 'mazacoin'),

--- a/lib/chains/__init__.py
+++ b/lib/chains/__init__.py
@@ -7,4 +7,5 @@ import litecoin
 import viacoin
 import dash
 import peercoin
+import blackcoin
 #__all__ = ['cryptocur, bitcoin, mazacoin']

--- a/lib/chains/blackcoin.py
+++ b/lib/chains/blackcoin.py
@@ -1,0 +1,174 @@
+'''Chain-specific Blackcoin code'''
+from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex, sha256, Hash, chainhook
+import os
+import time
+
+class Blackcoin(CryptoCur):
+    PoW = False
+    chain_index = 10
+    coin_name = 'Blackcoin'
+    code = 'BLK'
+    p2pkh_version = 25
+    p2sh_version = 85
+    wif_version = 153
+    ext_pub_version = '0488b21e'
+    ext_priv_version = '0488ade4'
+
+    DUST_THRESHOLD = 5430
+    MIN_RELAY_TX_FEE = 10000
+    RECOMMENDED_FEE = 50000
+    COINBASE_MATURITY = 500
+
+    block_explorers = {
+        'Coinplorer.com': 'https://coinplorer.com/BC/Transactions/',
+        'Bchain.info': 'https://bchain.info/BC/tx/'
+    }
+
+    base_units = {
+        'BLK': 8
+    }
+
+    chunk_size = 2016
+
+    # Network
+    DEFAULT_PORTS = {'t':'50001', 's':'50002', 'h':'8081', 'g':'8082'}
+
+    DEFAULT_SERVERS = {
+        'blk-cce-1.coinomi.net':{'t':'5015','s':'5015','h':'8081','g':'8082'},
+        'blk-cce-2.coinomi.net':{'t':'5015','s':'5015','h':'8081','g':'8082'}
+    }
+
+    def verify_chain(self, chain):
+
+        first_header = chain[0]
+        prev_header = self.read_header(first_header.get('block_height') -1)
+
+        if not self.PoW:
+            for header in chain:
+                prev_hash = self.hash_header(prev_header)
+                try:
+                    assert prev_hash == header.get('prev_block_hash')
+                except Exception:
+                    return False
+            return True
+
+        for header in chain:
+
+            height = header.get('block_height')
+
+            prev_hash = self.hash_header(prev_header)
+            bits, target = self.get_target(height/2016, chain)
+            _hash = self.hash_header(header)
+            try:
+                assert prev_hash == header.get('prev_block_hash')
+                assert bits == header.get('bits')
+                assert int('0x'+_hash,16) < target
+            except Exception:
+                return False
+
+            prev_header = header
+
+        return True
+
+
+    def verify_chunk(self, index, hexdata):
+        data = hexdata.decode('hex')
+        height = index*2016
+        num = len(data)/80
+
+        if index == 0:
+            previous_hash = ("0"*64)
+        else:
+            prev_header = self.read_header(index*2016-1)
+            if prev_header is None: raise
+            previous_hash = self.hash_header(prev_header)
+
+        if not self.PoW:
+            for i in range(num):
+                raw_header = data[i*80:(i+1)*80]
+                header = self.header_from_string(raw_header)
+                _hash = self.hash_header(header)
+                assert previous_hash == header.get('prev_block_hash')
+                previous_header = header
+                previous_hash = _hash
+            self.save_chunk(index, data)
+            return
+
+        bits, target = self.get_target(index)
+
+        for i in range(num):
+            height = index*2016 + i
+            raw_header = data[i*80:(i+1)*80]
+            header = self.header_from_string(raw_header)
+            _hash = self.hash_header(header)
+            assert previous_hash == header.get('prev_block_hash')
+            assert bits == header.get('bits')
+            assert int('0x'+_hash,16) < target
+
+            previous_header = header
+            previous_hash = _hash
+
+        self.save_chunk(index, data)
+
+    def hash_header(self, header):
+        return rev_hex(Hash(self.header_to_string(header).decode('hex')).encode('hex'))
+
+    def get_target(self, index, chain=None):
+        if chain is None:
+            chain = []  # Do not use mutables as default values!
+
+        max_target = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+        if index == 0: return 0x1d00ffff, max_target
+
+        first = self.read_header((index-1)*2016)
+        last = self.read_header(index*2016-1)
+        if last is None:
+            for h in chain:
+                if h.get('block_height') == index*2016-1:
+                    last = h
+
+        nActualTimespan = last.get('timestamp') - first.get('timestamp')
+        nTargetTimespan = 14*24*60*60
+        nActualTimespan = max(nActualTimespan, nTargetTimespan/4)
+        nActualTimespan = min(nActualTimespan, nTargetTimespan*4)
+
+        bits = last.get('bits')
+        # convert to bignum
+        MM = 256*256*256
+        a = bits%MM
+        if a < 0x8000:
+            a *= 256
+        target = (a) * pow(2, 8 * (bits/MM - 3))
+
+        # new target
+        new_target = min( max_target, (target * nActualTimespan)/nTargetTimespan )
+
+        # convert it to bits
+        c = ("%064X"%new_target)[2:]
+        i = 31
+        while c[0:2]=="00":
+            c = c[2:]
+            i -= 1
+
+        c = int('0x'+c[0:6],16)
+        if c >= 0x800000:
+            c /= 256
+            i += 1
+
+        new_bits = c + MM * i
+        return new_bits, new_target
+
+    @chainhook
+    def transaction_deserialize_tx_fields(self, vds, fields):
+        timestamp = ('timestamp', vds.read_int32, True)
+        fields.insert(1, timestamp)
+
+    @chainhook
+    def transaction_serialize(self, tx, for_sig, fields):
+        unix_time = getattr(tx, 'timestamp', None)
+        if unix_time is None:
+            unix_time = int(time.time())
+        timestamp = ('timestamp', int_to_hex(unix_time, 4))
+        fields.insert(1, timestamp)
+
+Currency = Blackcoin

--- a/lib/chains/blackcoin.py
+++ b/lib/chains/blackcoin.py
@@ -3,6 +3,8 @@ from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex, 
 import os
 import time
 
+from ltc_scrypt import getPoWHash
+
 class Blackcoin(CryptoCur):
     PoW = False
     chain_index = 10
@@ -111,7 +113,10 @@ class Blackcoin(CryptoCur):
         self.save_chunk(index, data)
 
     def hash_header(self, header):
-        return rev_hex(Hash(self.header_to_string(header).decode('hex')).encode('hex'))
+        if header.get('version', 0) > 6:
+            return rev_hex(Hash(self.header_to_string(header).decode('hex')).encode('hex'))
+        else:
+            return rev_hex(getPoWHash(self.header_to_string(header).decode('hex')).encode('hex'))
 
     def get_target(self, index, chain=None):
         if chain is None:

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -865,7 +865,7 @@ class Transaction:
                     secexp = pkey.secret
                     private_key = ecdsa.SigningKey.from_secret_exponent( secexp, curve = SECP256k1 )
                     public_key = private_key.get_verifying_key()
-                    sig = private_key.sign_digest_deterministic( for_sig, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der )
+                    sig = private_key.sign_digest_deterministic( for_sig, hashfunc=hashlib.sha256, sigencode = ecdsa.util.sigencode_der_canonize )
                     assert public_key.verify_digest( sig, for_sig, sigdecode = ecdsa.util.sigdecode_der)
                     txin['signatures'][ii] = sig.encode('hex')
                     self.inputs[i] = txin

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ setup(
         'chainkey.chains.viacoin',
         'chainkey.chains.dash',
         'chainkey.chains.peercoin',
+        'chainkey.chains.blackcoin',
         'chainkey_gui.gtk',
         'chainkey_gui.qt.__init__',
         'chainkey_gui.qt.amountedit',


### PR DESCRIPTION
In addition to implementing Blackcoin, this PR changes the behavior of Transaction.sign(). Now, signatures in transactions are canonical. (Basically, canonical signatures are as small as they can be.)
