### PR TITLE
Make hash algorithms modular; Implement Groestlcoin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install slowaes==0.1a1 ecdsa>=0.9 pbkdf2 requests pyasn1 pyasn1-modules tlslite>=0.4.5 qrcode SocksiPy-branch ltc_scrypt
   - git clone https://github.com/kefkius/coinhash
   - cd coinhash
-  - git checkout v1.0
+  - git checkout 1.1
   - python setup.py install
   - cd ..
 script: nosetests -e gui

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -7,6 +7,7 @@ from network import Network, DEFAULT_SERVERS, DEFAULT_PORTS, pick_random_server
 from interface import Interface
 from simple_config import SimpleConfig, get_config, set_config
 import coinhash
+import hashes
 import bitcoin
 import base58
 import eckey

--- a/lib/base58.py
+++ b/lib/base58.py
@@ -1,7 +1,8 @@
 import hashlib
 import re
 
-from util_coin import sha256, Hash
+from hashes import base58_hash
+from util_coin import sha256
 
 ############ functions from pywallet #####################
 
@@ -22,7 +23,7 @@ def public_key_to_bc_address(public_key, addrtype=0):
 
 def hash_160_to_bc_address(h160, addrtype = 0):
     vh160 = chr(addrtype) + h160
-    h = Hash(vh160)
+    h = base58_hash(vh160)
     addr = vh160 + h[0:4]
     return b58encode(addr)
 
@@ -84,7 +85,7 @@ def b58decode(v, length):
 
 def EncodeBase58Check(vchIn):
     """Encodes a string of bytes in Base58 encoding with a checksum."""
-    hash = Hash(vchIn)
+    hash = base58_hash(vchIn)
     return b58encode(vchIn + hash[0:4])
 
 
@@ -93,7 +94,7 @@ def DecodeBase58Check(psz):
     vchRet = b58decode(psz, None)
     key = vchRet[0:-4]
     csum = vchRet[-4:]
-    hash = Hash(key)
+    hash = base58_hash(key)
     cs32 = hash[0:4]
     if cs32 != csum:
         return None

--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from util import print_error
 import importlib
 import traceback, sys
+import hashes
 import chains
 import chains.cryptocur
 
@@ -58,6 +59,8 @@ def get_active_chain():
 def set_active_chain(chaincode):
     global active_chain
     active_chain = get_chain_instance(chaincode)
+    hashes.set_base58_hash(active_chain.base58_hash)
+    hashes.set_transaction_hash(active_chain.transaction_hash)
 
 def is_known_chain(code):
     code = code.upper()

--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -124,10 +124,10 @@ def get_chain_instance(code):
     module_name = params.module_name
     # If importing fails, try with a different path.
     try:
+        classmodule = importlib.import_module(''.join(['lib.chains.', module_name]))
+    except (AttributeError, ImportError):
         classmodule = importlib.import_module(''.join(['chainkey.chains.', module_name]))
         classInst = getattr(classmodule, 'Currency')
-    except (AttributeError, ImportError):
-        classmodule = importlib.import_module(''.join(['lib.chains.', module_name]))
     classInst = getattr(classmodule, 'Currency')
     return classInst()
 

--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -46,6 +46,9 @@ _known_chains = (
 
     # Viacoin
     ChainParams(14, 'Viacoin', 'VIA', 'viacoin'),
+
+    # Groestlcoin
+    ChainParams(17, 'Groestlcoin', 'GRS', 'groestlcoin'),
 )
 
 _known_chain_dict = dict((i.code, i) for i in _known_chains)

--- a/lib/chains/README.md
+++ b/lib/chains/README.md
@@ -8,7 +8,9 @@ The class for a chainkey module must derive from the CryptoCur class.
 
 ## Writing a chainkey module
 
-### Variables
+### Attributes
+
+#### Chain Params
 
 Chainkey modules require a set of constants for identifying the coin. These include:
 
@@ -27,6 +29,24 @@ The following constants are not yet fully implemented, but should be included:
 
 - `ext_pub_version`: Extended public key version bytes; "0488b21e" for Bitcoin.
 - `ext_priv_version`: Extended private key version bytes; "0488ade4" for Bitcoin.
+
+#### Hash Algorithms
+
+Most coins use SHA256d (two rounds of SHA256) for all cases where a hash algorithm is needed. Even coins that use alternative
+algorithms usually just use them for proof-of-work purposes only. If the coin uses an algorithm other than SHA256d for something,
+set the corresponding attribute below to the corresponding function in coinhash.
+
+**Note**: The `coinhash` package must be used for all coin-specific hashes. It's a collection of hash algorithms, and it makes
+things a lot easier to manage. Coinhash is located (here)[https://github.com/Kefkius/coinhash].
+
+##### Example of Alternative Hash Algorithms
+
+|Purpose             |Algorithm      |Example of chainkey module code       |
+|--------------------|---------------|--------------------------------------|
+|base58 encoding     |Skein          |`base58_hash = coinhash.SkeinHash`    |
+|transaction hashing |X11            |`transaction_hash = coinhash.X11Hash` |
+
+#### Info About the Chain
 
 In addition to those constants, some more modular information is required, including:
 
@@ -54,5 +74,6 @@ If an electrum fork has a custom method to call when a chain reorg occurs, it sh
 ## Implementation
 
 To implement a new chain after writing a chainkey module, place the coin's module in lib/chains with the others. Then edit lib/chainparams.py, adding a ChainParams named-tuple for that coin in `_known_chains`. When a chain is in `_known_chains`, Encompass will be able to use it as long as its metadata is correct.
+In the file `lib/chains/__init__.py`, a line that says `import yourcoin`, where `yourcoin` is the name of the new chainkey module, is required.
 
 For installation purposes, also add the module to the `py_modules` list in setup.py, as Bitcoin is done [here](https://github.com/mazaclub/encompass/blob/master/setup.py#L117).

--- a/lib/chains/__init__.py
+++ b/lib/chains/__init__.py
@@ -8,3 +8,4 @@ import peercoin
 import dogecoin
 import blackcoin
 import feathercoin
+import groestlcoin

--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -1,6 +1,7 @@
 '''The base class for a cryptocurrency.'''
 
 import os, hashlib
+import coinhash
 
 hash_encode = lambda x: x[::-1].encode('hex')
 hash_decode = lambda x: x.decode('hex')[::-1]
@@ -60,6 +61,9 @@ class CryptoCur(object):
     RECOMMENDED_FEE = 50000
     COINBASE_MATURITY = 100
 
+    ### Hash Algorithms ###
+    base58_hash = coinhash.SHA256dHash
+    transaction_hash = coinhash.SHA256dHash
 
     # Block explorers {name : URL}
     block_explorers = {

--- a/lib/chains/groestlcoin.py
+++ b/lib/chains/groestlcoin.py
@@ -1,0 +1,220 @@
+from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex
+import os
+
+import coinhash
+
+class Groestlcoin(CryptoCur):
+    PoW = True
+    chain_index = 17
+    coin_name = 'Groestlcoin'
+    code = 'GRS'
+    p2pkh_version = 36
+    p2sh_version = 5
+    wif_version = 164
+    ext_pub_version = '0488b21e'
+    ext_priv_version = '0488ade4'
+
+    DUST_THRESHOLD = 5430
+    MIN_RELAY_TX_FEE = 2000000
+    RECOMMENDED_FEE = 2000000
+    COINBASE_MATURITY = 100
+
+    base58_hash = coinhash.GroestlHash
+    transaction_hash = coinhash.SHA256Hash
+
+    block_explorers = {
+        'cryptoID.info': 'https://chainz.cryptoid.info/grs/tx.dws?',
+        'MultiFaucet.tk': 'http://www.multifaucet.tk/index.php?blockexplorer=GRS&txid='
+    }
+
+    base_units = {
+        'GRS': 8
+    }
+
+    chunk_size = 2016
+
+    DEFAULT_PORTS = {'t':'50001', 's':'50002', 'h':'8081', 'g':'8082'}
+
+    DEFAULT_SERVERS = {
+        'electrum1.groestlcoin.org':DEFAULT_PORTS,
+        'electrum2.groestlcoin.org':DEFAULT_PORTS,
+    }
+
+    def reorg_handler(self, local_height):
+        name = self.path()
+        if os.path.exists(name):
+            f = open(name, 'rb+')
+            f.seek( (local_height - 100) *80)
+            f.truncate()
+            f.close()
+
+
+    def verify_chain(self, chain):
+
+        first_header = chain[0]
+        prev_header = self.read_header(first_header.get('block_height') -1)
+
+        for header in chain:
+
+            height = header.get('block_height')
+
+            prev_hash = self.hash_header(prev_header)
+            if height >= 100000:
+                bits, target = self.get_target(height, chain)
+            _hash = self.hash_header(header)
+            try:
+                assert prev_hash == header.get('prev_block_hash')
+                if height >= 100000:
+                    assert bits == header.get('bits')
+                    assert int('0x'+_hash,16) < target
+            except Exception:
+                return False
+
+            prev_header = header
+
+        return True
+
+    def verify_chunk(self, index, hexdata):
+        data = hexdata.decode('hex')
+        height = index*2016
+        num = len(data)/80
+
+        if index == 0:
+            previous_hash = ("0"*64)
+        else:
+            prev_header = self.read_header(index*2016-1)
+            if prev_header is None: raise
+            previous_hash = self.hash_header(prev_header)
+
+        #bits, target = self.get_target(index)
+
+        for i in range(num):
+            height = index*2016 + i
+            raw_header = data[i*80:(i+1)*80]
+            header = self.header_from_string(raw_header)
+            _hash = self.hash_header(header)
+            assert previous_hash == header.get('prev_block_hash')
+            # If using diff retarget, calculate/verify bits
+            if self.PoW and height >= 100000:
+                bits, target = self.get_target(height)
+                assert bits == header.get('bits')
+                assert int('0x'+_hash,16) < target
+            if self.PoW:
+                self.save_header(header, height)
+
+            previous_header = header
+            previous_hash = _hash
+
+        if self.PoW == False:
+            self.save_chunk(index, data)
+
+    def hash_header(self, header):
+        return rev_hex(coinhash.GroestlHash(self.header_to_string(header).decode('hex')).encode('hex'))
+
+    def save_header(self, header, height=None):
+        data = self.header_to_string(header).decode('hex')
+        assert len(data) == 80
+        if height is None: height = header.get('block_height')
+        filename = self.path()
+        f = open(filename,'rb+')
+        f.seek(height*80)
+        h = f.write(data)
+        f.close()
+
+    def bits_to_target(self, bits):
+        MM = 256*256*256
+        a = bits%MM
+        if a < 0x8000:
+            a *= 256
+        target = (a) * pow(2, 8 * (bits/MM - 3))
+        return target
+
+    def target_to_bits(self, target):
+        MM = 256*256*256
+        c = ("%064X"%target)[2:]
+        i = 31
+        while c[0:2]=="00":
+            c = c[2:]
+            i -= 1
+
+        c = int('0x'+c[0:6],16)
+        if c >= 0x800000:
+            c /= 256
+            i += 1
+
+        new_bits = c + MM * i
+        return new_bits
+
+
+    def get_target_dgw3(self, block_height, chain=None):
+        if chain is None:
+            chain = []
+
+        last = self.read_header(block_height-1)
+        if last is None:
+            for h in chain:
+                if h.get('block_height') == block_height-1:
+                    last = h
+
+        # params
+        BlockLastSolved = last
+        BlockReading = last
+        BlockCreating = block_height
+        nActualTimespan = 0
+        LastBlockTime = 0
+        PastBlocksMin = 24
+        PastBlocksMax = 24
+        CountBlocks = 0
+        PastDifficultyAverage = 0
+        PastDifficultyAveragePrev = 0
+        bnNum = 0
+
+        max_target = 0x00000FFFF0000000000000000000000000000000000000000000000000000000
+
+        if BlockLastSolved is None or block_height-1 < PastBlocksMin:
+            return 0x1e0ffff0, max_target
+        for i in range(1, PastBlocksMax + 1):
+            CountBlocks += 1
+
+            if CountBlocks <= PastBlocksMin:
+                if CountBlocks == 1:
+                    PastDifficultyAverage = self.bits_to_target(BlockReading.get('bits'))
+                else:
+                    bnNum = self.bits_to_target(BlockReading.get('bits'))
+                    PastDifficultyAverage = ((PastDifficultyAveragePrev * CountBlocks)+(bnNum)) / (CountBlocks + 1)
+                PastDifficultyAveragePrev = PastDifficultyAverage
+
+            if LastBlockTime > 0:
+                Diff = (LastBlockTime - BlockReading.get('timestamp'))
+                nActualTimespan += Diff
+            LastBlockTime = BlockReading.get('timestamp')
+
+            BlockReading = self.read_header((block_height-1) - CountBlocks)
+            if BlockReading is None:
+                for br in chain:
+                    if br.get('block_height') == (block_height-1) - CountBlocks:
+                        BlockReading = br
+
+        bnNew = PastDifficultyAverage
+        nTargetTimespan = CountBlocks * 60
+
+        nActualTimespan = max(nActualTimespan, nTargetTimespan/3)
+        nActualTimespan = min(nActualTimespan, nTargetTimespan*3)
+
+        # retarget
+        bnNew *= nActualTimespan
+        bnNew /= nTargetTimespan
+        bnNew = min(bnNew, max_target)
+
+        new_bits = self.target_to_bits(bnNew)
+        return new_bits, bnNew
+
+    def get_target(self, block_height, chain=None):
+        if chain is None:
+            chain = []  # Do not use mutables as default values!
+
+        # DGW3 starts at block 99,999
+        assert block_height >= 100000
+        return self.get_target_dgw3(block_height, chain)
+
+Currency = Groestlcoin

--- a/lib/hashes.py
+++ b/lib/hashes.py
@@ -1,0 +1,45 @@
+"""Hash algorithms."""
+
+import coinhash
+
+# Algorithms
+#
+# base58: Used in address encoding and Base58Check encoding.
+# transaction: Used to hash transactions.
+hash_algos = {
+    'base58': coinhash.SHA256dHash,
+    'transaction': coinhash.SHA256dHash,
+}
+
+def set_hash_algo(name, hash_algo):
+    """Generic function for setting an algorithm.
+
+    Specific functions should be used whenever possible.
+    This is just for extensibility.
+    """
+    global hash_algos
+    hash_algos[name] = hash_algo
+
+def set_base58_hash(hash_algo):
+    """Set the global hash algorithm used in base58 encoding."""
+    global hash_algos
+    hash_algos['base58'] = hash_algo
+
+def set_transaction_hash(hash_algo):
+    """Set the global hash algorithm used in transaction hashing."""
+    global hash_algos
+    hash_algos['transaction'] = hash_algo
+
+
+def do_hash(algo, x):
+    """Some hash algorithms require a different number of args."""
+    if algo is coinhash.GroestlHash:
+        return algo(x, len(x))
+    else:
+        return algo(x)
+
+def base58_hash(x):
+    return do_hash(hash_algos['base58'], x)
+
+def transaction_hash(x):
+    return do_hash(hash_algos['transaction'], x)

--- a/lib/hashes.py
+++ b/lib/hashes.py
@@ -33,6 +33,8 @@ def set_transaction_hash(hash_algo):
 
 def do_hash(algo, x):
     """Some hash algorithms require a different number of args."""
+    # Convert from a class method to a coinhash function
+    algo = getattr(coinhash, algo.__name__)
     if algo is coinhash.GroestlHash:
         return algo(x, len(x))
     else:

--- a/lib/hashes.py
+++ b/lib/hashes.py
@@ -32,13 +32,9 @@ def set_transaction_hash(hash_algo):
 
 
 def do_hash(algo, x):
-    """Some hash algorithms require a different number of args."""
-    # Convert from a class method to a coinhash function
+    """Convert the algo from a class method to a coinhash function."""
     algo = getattr(coinhash, algo.__name__)
-    if algo is coinhash.GroestlHash:
-        return algo(x, len(x))
-    else:
-        return algo(x)
+    return algo(x)
 
 def base58_hash(x):
     return do_hash(hash_algos['base58'], x)

--- a/lib/synchronizer.py
+++ b/lib/synchronizer.py
@@ -21,7 +21,8 @@ import threading
 import time
 import Queue
 
-import bitcoin
+import util_coin
+import hashes
 from util import print_error
 from transaction import Transaction
 
@@ -179,7 +180,7 @@ class WalletSynchronizer(threading.Thread):
             elif method == 'blockchain.transaction.get':
                 tx_hash = params[0]
                 tx_height = params[1]
-                assert tx_hash == bitcoin.hash_encode(bitcoin.Hash(result.decode('hex')))
+                assert tx_hash == util_coin.hash_encode(hashes.transaction_hash(result.decode('hex')))
                 tx = Transaction.deserialize(result)
                 self.wallet.receive_tx_callback(tx_hash, tx, tx_height)
                 self.was_updated = True

--- a/lib/tests/test_hashes.py
+++ b/lib/tests/test_hashes.py
@@ -38,4 +38,4 @@ class Test_hashes(unittest.TestCase):
         block_header = '70000000f16294cc9ddf97d62ea373831410aef4118046ed4b8e176e05fd730e0000000009b85cf20e75305ed1b661ef17edb8ff510b352b08bdb5b2831193cd99076799ebf33b540272101c78a6eb00'
         actual_pow_hash = '0000000006578229b1483120424c209574fb8d5b7f900b52362b2627a716bf9f'
 
-        self.assertEqual(actual_pow_hash, rev_hex(coinhash.GroestlHash(block_header.decode('hex'), len(block_header.decode('hex'))).encode('hex')))
+        self.assertEqual(actual_pow_hash, rev_hex(coinhash.GroestlHash(block_header.decode('hex')).encode('hex')))

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'chainkey.commands',
         'chainkey.daemon',
         'chainkey.eckey',
+        'chainkey.hashes',
         'chainkey.i18n',
         'chainkey.interface',
         'chainkey.mnemonic',

--- a/setup.py
+++ b/setup.py
@@ -78,11 +78,11 @@ setup(
 	'tlslite==0.4.8',
 	'dnspython',
 	'trezor==0.6.3',
-        'coinhash==1.0'
+        'coinhash==1.1'
     ],
     dependency_links=[
         "git+https://github.com/mazaclub/python-trezor#egg=trezor",
-        "git+https://github.com/kefkius/coinhash#egg=coinhash"
+        "git+https://github.com/kefkius/coinhash#egg=coinhash-1.1"
     ],
     package_dir={
         'chainkey': 'lib',
@@ -135,6 +135,7 @@ setup(
         'chainkey.chains.dogecoin',
         'chainkey.chains.blackcoin',
         'chainkey.chains.feathercoin',
+        'chainkey.chains.groestlcoin',
         'chainkey_gui.gtk',
         'chainkey_gui.qt.__init__',
         'chainkey_gui.qt.amountedit',


### PR DESCRIPTION
Hash algorithms for various cases can now be specified in chainkey modules.

These changes allow coins like Groestlcoin, which uses a hash other than SHA256d for transaction and base58 hashing, to be implemented. And so Groestlcoin is implemented as an example.
