### PR TITLE
Add option for verbosity of Change Currency window

### DIFF
--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -20,25 +20,10 @@ class ChangeCurrencyDialog(QDialog):
         self.main_layout = main_layout = QVBoxLayout()
 
         self.create_chains_info()
-
         self.create_chains_view()
+        self.refresh_chains()
+
         chains_view = self.chains_view
-        chains = chainparams.known_chains
-        # Yes or No
-        y_or_n = lambda x: 'Yes' if x==True else 'No'
-        for ch in sorted(chains, key=operator.attrgetter('code')):
-
-            is_initialized = True
-            dummy_key = self.parent.wallet.storage.get_chain_value(ch.code, 'accounts')
-            if dummy_key is None:
-                is_initialized = False
-
-            server_trust = chainparams.get_server_trust(ch.code)
-            uses_pow = server_trust['pow']
-            num_servers = server_trust['servers']
-            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized), y_or_n(uses_pow), str(num_servers)])
-            chains_view.addTopLevelItem(item)
-        chains_view.setCurrentItem(chains_view.topLevelItem(0))
         main_layout.addWidget(chains_view)
 
         main_layout.addLayout(ok_cancel_buttons(self))

--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -5,7 +5,7 @@ from PyQt4.QtCore import *
 from chainkey.i18n import _
 from chainkey import chainparams
 
-from util import ok_cancel_buttons
+from util import HelpButton, ok_cancel_buttons
 
 import operator
 
@@ -17,30 +17,58 @@ class ChangeCurrencyDialog(QDialog):
         self.setWindowTitle(_('Change Currency'))
 
         main_layout = QVBoxLayout()
-        change_info = QLabel(_("Note that you will need to enter your password the first time you use a new currency.\n"))
+        change_info = QLabel(_("Select a currency to start using it. The key below explains the columns in the currency table."))
         change_info.setWordWrap(True)
         main_layout.addWidget(change_info)
 
-        key_info = QLabel(_("PoW: Whether this wallet verifies proof-of-work.\nServers: Number of default servers to get data from."))
-        key_info.setWordWrap(True)
-        main_layout.addWidget(key_info)
+        change_sep = QFrame()
+        change_sep.setFrameShape(QFrame.HLine)
+        change_sep.setFrameShadow(QFrame.Sunken)
+        main_layout.addWidget(change_sep)
+
+        # Explanation of table columns
+        key_layout = QGridLayout()
+        key_layout.setSpacing(0)
+        key_layout.setColumnMinimumWidth(0, 75)
+        key_layout.setColumnStretch(1, 1)
+
+        key_layout.addWidget(QLabel(_('Initialized:')), 0, 0)
+        key_layout.addWidget(QLabel(_('Whether this currency has been activated before.')), 0, 1)
+        key_layout.addWidget(HelpButton(_('The first time you use a currency, you must enter your password to initialize it.')), 0, 2)
+
+        key_layout.addWidget(QLabel(_('PoW:')), 1, 0)
+        key_layout.addWidget(QLabel(_('Whether this wallet verifies proof-of-work.')), 1, 1)
+        key_layout.addWidget(HelpButton(_('Verifying proof-of-work helps ensure that data the wallet receives is legitimate.')), 1, 2)
+
+        key_layout.addWidget(QLabel(_('Servers:')), 2, 0)
+        key_layout.addWidget(QLabel(_('Number of default servers this currency has.')), 2, 1)
+        key_layout.addWidget(HelpButton(_('The more servers there are, the less trust has to be placed in one party.')), 2, 2)
+
+        main_layout.addLayout(key_layout)
 
         self.chains_view = chains_view = QTreeWidget()
         chains_view.setColumnCount(4)
-        chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('PoW'), _('Servers') ])
-        chains_view.setColumnWidth(0, 75)
-        chains_view.setColumnWidth(1, 125)
-        chains_view.setColumnWidth(2, 60)
-        chains_view.setColumnWidth(3, 50)
-        chains_view.setMinimumWidth(325)
+        chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('Initialized'), _('PoW'), _('Servers') ])
+        chains_view.setColumnWidth(0, 90)
+        chains_view.setColumnWidth(1, 150)
+        chains_view.setColumnWidth(2, 80)
+        chains_view.setColumnWidth(3, 60)
+        chains_view.setColumnWidth(4, 50)
+        chains_view.setMinimumWidth(500)
         chains = chainparams._known_chains
         # Yes or No
         y_or_n = lambda x: 'Yes' if x==True else 'No'
         for ch in sorted(chains, key=operator.attrgetter('code')):
+
+            is_initialized = True
+            dummy_key = self.parent.wallet.storage.get_chain_value(ch.code, 'accounts')
+            if dummy_key is None:
+                is_initialized = False
+
             server_trust = chainparams.get_server_trust(ch.code)
             uses_pow = server_trust['pow']
             num_servers = server_trust['servers']
-            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(uses_pow), str(num_servers)])
+            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized), y_or_n(uses_pow), str(num_servers)])
             chains_view.addTopLevelItem(item)
         chains_view.setCurrentItem(chains_view.topLevelItem(0))
         main_layout.addWidget(chains_view)
@@ -49,3 +77,23 @@ class ChangeCurrencyDialog(QDialog):
 
         self.setLayout(main_layout)
 
+    def refresh_chains(self):
+        chains_view = self.chains_view
+        chains_view.clear()
+
+        chains = chainparams._known_chains
+        # Yes or No
+        y_or_n = lambda x: 'Yes' if x==True else 'No'
+        for ch in sorted(chains, key=operator.attrgetter('code')):
+
+            is_initialized = True
+            dummy_key = self.parent.wallet.storage.get_chain_value(ch.code, 'accounts')
+            if dummy_key is None:
+                is_initialized = False
+
+            server_trust = chainparams.get_server_trust(ch.code)
+            uses_pow = server_trust['pow']
+            num_servers = server_trust['servers']
+            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized), y_or_n(uses_pow), str(num_servers)])
+            chains_view.addTopLevelItem(item)
+        chains_view.setCurrentItem(chains_view.topLevelItem(0))

--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -55,7 +55,7 @@ class ChangeCurrencyDialog(QDialog):
         chains_view.setColumnWidth(3, 60)
         chains_view.setColumnWidth(4, 50)
         chains_view.setMinimumWidth(500)
-        chains = chainparams._known_chains
+        chains = chainparams.known_chains
         # Yes or No
         y_or_n = lambda x: 'Yes' if x==True else 'No'
         for ch in sorted(chains, key=operator.attrgetter('code')):
@@ -81,7 +81,7 @@ class ChangeCurrencyDialog(QDialog):
         chains_view = self.chains_view
         chains_view.clear()
 
-        chains = chainparams._known_chains
+        chains = chainparams.known_chains
         # Yes or No
         y_or_n = lambda x: 'Yes' if x==True else 'No'
         for ch in sorted(chains, key=operator.attrgetter('code')):

--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -1,0 +1,51 @@
+import PyQt4
+from PyQt4.QtGui import *
+from PyQt4.QtCore import *
+
+from chainkey.i18n import _
+from chainkey import chainparams
+
+from util import ok_cancel_buttons
+
+import operator
+
+class ChangeCurrencyDialog(QDialog):
+
+    def __init__(self, parent):
+        QDialog.__init__(self, parent)
+        self.parent = parent
+        self.setWindowTitle(_('Change Currency'))
+
+        main_layout = QVBoxLayout()
+        change_info = QLabel(_("Note that you will need to enter your password the first time you use a new currency.\n"))
+        change_info.setWordWrap(True)
+        main_layout.addWidget(change_info)
+
+        key_info = QLabel(_("PoW: Whether this wallet verifies proof-of-work.\nServers: Number of default servers to get data from."))
+        key_info.setWordWrap(True)
+        main_layout.addWidget(key_info)
+
+        self.chains_view = chains_view = QTreeWidget()
+        chains_view.setColumnCount(4)
+        chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('PoW'), _('Servers') ])
+        chains_view.setColumnWidth(0, 75)
+        chains_view.setColumnWidth(1, 125)
+        chains_view.setColumnWidth(2, 60)
+        chains_view.setColumnWidth(3, 50)
+        chains_view.setMinimumWidth(325)
+        chains = chainparams._known_chains
+        # Yes or No
+        y_or_n = lambda x: 'Yes' if x==True else 'No'
+        for ch in sorted(chains, key=operator.attrgetter('code')):
+            server_trust = chainparams.get_server_trust(ch.code)
+            uses_pow = server_trust['pow']
+            num_servers = server_trust['servers']
+            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(uses_pow), str(num_servers)])
+            chains_view.addTopLevelItem(item)
+        chains_view.setCurrentItem(chains_view.topLevelItem(0))
+        main_layout.addWidget(chains_view)
+
+        main_layout.addLayout(ok_cancel_buttons(self))
+
+        self.setLayout(main_layout)
+

--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -11,50 +11,18 @@ import operator
 
 class ChangeCurrencyDialog(QDialog):
 
-    def __init__(self, parent):
+    def __init__(self, parent, verbose_view=False):
         QDialog.__init__(self, parent)
         self.parent = parent
+        self.verbose_view = verbose_view
         self.setWindowTitle(_('Change Currency'))
 
-        main_layout = QVBoxLayout()
-        change_info = QLabel(_("Select a currency to start using it. The key below explains the columns in the currency table."))
-        change_info.setWordWrap(True)
-        main_layout.addWidget(change_info)
+        self.main_layout = main_layout = QVBoxLayout()
 
-        change_sep = QFrame()
-        change_sep.setFrameShape(QFrame.HLine)
-        change_sep.setFrameShadow(QFrame.Sunken)
-        main_layout.addWidget(change_sep)
+        self.create_chains_info()
 
-        # Explanation of table columns
-        key_layout = QGridLayout()
-        key_layout.setSpacing(0)
-        key_layout.setColumnMinimumWidth(0, 75)
-        key_layout.setColumnStretch(1, 1)
-
-        key_layout.addWidget(QLabel(_('Initialized:')), 0, 0)
-        key_layout.addWidget(QLabel(_('Whether this currency has been activated before.')), 0, 1)
-        key_layout.addWidget(HelpButton(_('The first time you use a currency, you must enter your password to initialize it.')), 0, 2)
-
-        key_layout.addWidget(QLabel(_('PoW:')), 1, 0)
-        key_layout.addWidget(QLabel(_('Whether this wallet verifies proof-of-work.')), 1, 1)
-        key_layout.addWidget(HelpButton(_('Verifying proof-of-work helps ensure that data the wallet receives is legitimate.')), 1, 2)
-
-        key_layout.addWidget(QLabel(_('Servers:')), 2, 0)
-        key_layout.addWidget(QLabel(_('Number of default servers this currency has.')), 2, 1)
-        key_layout.addWidget(HelpButton(_('The more servers there are, the less trust has to be placed in one party.')), 2, 2)
-
-        main_layout.addLayout(key_layout)
-
-        self.chains_view = chains_view = QTreeWidget()
-        chains_view.setColumnCount(4)
-        chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('Initialized'), _('PoW'), _('Servers') ])
-        chains_view.setColumnWidth(0, 90)
-        chains_view.setColumnWidth(1, 150)
-        chains_view.setColumnWidth(2, 80)
-        chains_view.setColumnWidth(3, 60)
-        chains_view.setColumnWidth(4, 50)
-        chains_view.setMinimumWidth(500)
+        self.create_chains_view()
+        chains_view = self.chains_view
         chains = chainparams.known_chains
         # Yes or No
         y_or_n = lambda x: 'Yes' if x==True else 'No'
@@ -77,6 +45,25 @@ class ChangeCurrencyDialog(QDialog):
 
         self.setLayout(main_layout)
 
+    def create_chains_view(self):
+        self.chains_view = chains_view = QTreeWidget()
+        if self.verbose_view:
+            chains_view.setColumnCount(4)
+            chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('Initialized'), _('PoW'), _('Servers') ])
+            chains_view.setColumnWidth(0, 90)
+            chains_view.setColumnWidth(1, 150)
+            chains_view.setColumnWidth(2, 80)
+            chains_view.setColumnWidth(3, 60)
+            chains_view.setColumnWidth(4, 50)
+            chains_view.setMinimumWidth(500)
+        else:
+            chains_view.setColumnCount(2)
+            chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('Initialized') ])
+            chains_view.setColumnWidth(0, 90)
+            chains_view.setColumnWidth(1, 150)
+            chains_view.setColumnWidth(2, 80)
+            chains_view.setMinimumWidth(400)
+
     def refresh_chains(self):
         chains_view = self.chains_view
         chains_view.clear()
@@ -94,6 +81,41 @@ class ChangeCurrencyDialog(QDialog):
             server_trust = chainparams.get_server_trust(ch.code)
             uses_pow = server_trust['pow']
             num_servers = server_trust['servers']
-            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized), y_or_n(uses_pow), str(num_servers)])
+            if self.verbose_view:
+                item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized), y_or_n(uses_pow), str(num_servers)])
+            else:
+                item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(is_initialized)])
             chains_view.addTopLevelItem(item)
         chains_view.setCurrentItem(chains_view.topLevelItem(0))
+
+    def create_chains_info(self):
+        main_layout = self.main_layout
+        change_info = QLabel(_("Select a currency to start using it. The key below explains the column(s) in the currency table."))
+        change_info.setWordWrap(True)
+        main_layout.addWidget(change_info)
+
+        change_sep = QFrame()
+        change_sep.setFrameShape(QFrame.HLine)
+        change_sep.setFrameShadow(QFrame.Sunken)
+        main_layout.addWidget(change_sep)
+
+        # Explanation of table columns
+        self.key_layout = key_layout = QGridLayout()
+        key_layout.setSpacing(0)
+        key_layout.setColumnMinimumWidth(0, 75)
+        key_layout.setColumnStretch(1, 1)
+
+        key_layout.addWidget(QLabel(_('Initialized:')), 0, 0)
+        key_layout.addWidget(QLabel(_('Whether this currency has been activated before.')), 0, 1)
+        key_layout.addWidget(HelpButton(_('The first time you use a currency, you must enter your password to initialize it.')), 0, 2)
+
+        if self.verbose_view:
+            key_layout.addWidget(QLabel(_('PoW:')), 1, 0)
+            key_layout.addWidget(QLabel(_('Whether this wallet verifies proof-of-work.')), 1, 1)
+            key_layout.addWidget(HelpButton(_('Verifying proof-of-work helps ensure that data the wallet receives is legitimate.')), 1, 2)
+
+            key_layout.addWidget(QLabel(_('Servers:')), 2, 0)
+            key_layout.addWidget(QLabel(_('Number of default servers this currency has.')), 2, 1)
+            key_layout.addWidget(HelpButton(_('The more servers there are, the less trust has to be placed in one party.')), 2, 2)
+
+        main_layout.addLayout(key_layout)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1782,10 +1782,16 @@ class ElectrumWindow(QMainWindow):
 
     def change_currency_dialog(self):
         if self.change_currency_window is None:
-            self.change_currency_window = ChangeCurrencyDialog(self)
+            self.change_currency_window = ChangeCurrencyDialog(self, self.config.get_above_chain('verbose_currency_dialog', False))
             self.change_currency_window.chains_view.itemActivated.connect(self.on_currency_select)
         else:
             self.change_currency_window.refresh_chains()
+
+        # Refresh if the settings have changed
+        if self.change_currency_window.verbose_view != self.config.get_above_chain('verbose_currency_dialog', False):
+            self.change_currency_window.chains_view.itemActivated.disconnect()
+            self.change_currency_window = ChangeCurrencyDialog(self, self.config.get_above_chain('verbose_currency_dialog', False))
+            self.change_currency_window.chains_view.itemActivated.connect(self.on_currency_select)
 
         if not self.change_currency_window.exec_(): return
         self.on_currency_select()
@@ -2759,6 +2765,12 @@ class ElectrumWindow(QMainWindow):
         can_edit_fees_cb.stateChanged.connect(on_editfees)
         can_edit_fees_help = HelpButton(_('This option lets you edit fees in the send tab.'))
         widgets.append((can_edit_fees_cb, None, can_edit_fees_help))
+
+        verbose_currency_dialog = QCheckBox(_('Show verbose info in Change Currency window'))
+        verbose_currency_dialog.setChecked(self.config.get_above_chain('verbose_currency_dialog', False))
+        verbose_currency_dialog.stateChanged.connect(lambda x: self.config.set_key_above_chain('verbose_currency_dialog', verbose_currency_dialog.isChecked()))
+        verbose_currency_dialog_help = HelpButton(_('Show verbose information about currencies, such as the number of default servers.'))
+        widgets.append((verbose_currency_dialog, None, verbose_currency_dialog_help))
 
         use_def_wallet_cb = QCheckBox(_('Open default_wallet on wallet start'))
         use_def_wallet_cb.setChecked(self.config.get_above_chain('use_default_wallet', True))

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1784,6 +1784,8 @@ class ElectrumWindow(QMainWindow):
         if self.change_currency_window is None:
             self.change_currency_window = ChangeCurrencyDialog(self)
             self.change_currency_window.chains_view.itemActivated.connect(self.on_currency_select)
+        else:
+            self.change_currency_window.refresh_chains()
 
         if not self.change_currency_window.exec_(): return
         self.on_currency_select()

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -189,6 +189,7 @@ class ElectrumWindow(QMainWindow):
         self.payment_request = None
         self.qr_window = None
         self.not_enough_funds = False
+        self.change_currency_window = None
 
     def update_account_selector(self):
         # account selector
@@ -1780,10 +1781,11 @@ class ElectrumWindow(QMainWindow):
         self.update_lock_icon()
 
     def change_currency_dialog(self):
-        self.change_currency_window = d = ChangeCurrencyDialog(self)
-        d.chains_view.itemActivated.connect(self.on_currency_select)
+        if self.change_currency_window is None:
+            self.change_currency_window = ChangeCurrencyDialog(self)
+            self.change_currency_window.chains_view.itemActivated.connect(self.on_currency_select)
 
-        if not d.exec_(): return
+        if not self.change_currency_window.exec_(): return
         self.on_currency_select()
 
     def on_currency_select(self):

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -47,6 +47,7 @@ from amountedit import AmountEdit, BTCAmountEdit, MyLineEdit
 from network_dialog import NetworkDialog
 from qrcodewidget import QRCodeWidget, QRDialog
 from qrtextedit import ScanQRTextEdit, ShowQRTextEdit
+from currency_dialog import ChangeCurrencyDialog
 
 from decimal import Decimal
 
@@ -1779,47 +1780,14 @@ class ElectrumWindow(QMainWindow):
         self.update_lock_icon()
 
     def change_currency_dialog(self):
-        import operator
-        self.change_currency_window = d = QDialog(self)
-        d.setWindowTitle(_('Change Currency'))
-        main_layout = QVBoxLayout()
-        change_info = QLabel( _("Note that you will need to enter your password the first time you use a new currency.\n") )
-        change_info.setWordWrap(True)
-        main_layout.addWidget(change_info)
-
-        key_info = QLabel( _("PoW: Whether this wallet verifies proof-of-work.\nServers: Number of default servers to get data from.") )
-        key_info.setWordWrap(True)
-        main_layout.addWidget(key_info)
-
-        self.chains_view = chains_view = QTreeWidget()
-        chains_view.setColumnCount(4)
-        chains_view.setHeaderLabels([ _('Code'), _('Currency'), _('PoW'), _('Servers') ])
-        chains_view.setColumnWidth(0, 75)
-        chains_view.setColumnWidth(1, 125)
-        chains_view.setColumnWidth(2, 60)
-        chains_view.setColumnWidth(3, 50)
-        chains_view.setMinimumWidth(325)
-        chains_view.itemActivated.connect(self.on_currency_select)
-        chains = chainkey.chainparams.known_chains
-        # Yes or No
-        y_or_n = lambda x: 'Yes' if x==True else 'No'
-        for ch in sorted(chains, key=operator.attrgetter('code')):
-            server_trust = chainkey.chainparams.get_server_trust(ch.code)
-            uses_pow = server_trust['pow']
-            num_servers = server_trust['servers']
-            item = QTreeWidgetItem([ch.code, ch.coin_name, y_or_n(uses_pow), str(num_servers)])
-            chains_view.addTopLevelItem(item)
-        chains_view.setCurrentItem(chains_view.topLevelItem(0))
-        main_layout.addWidget(chains_view)
-
-        main_layout.addLayout(ok_cancel_buttons(d))
-        d.setLayout(main_layout)
+        self.change_currency_window = d = ChangeCurrencyDialog(self)
+        d.chains_view.itemActivated.connect(self.on_currency_select)
 
         if not d.exec_(): return
         self.on_currency_select()
 
     def on_currency_select(self):
-        chaincode = str(self.chains_view.currentItem().text(0))
+        chaincode = str(self.change_currency_window.chains_view.currentItem().text(0))
         self.change_currency_window.close()
         self.emit(QtCore.SIGNAL('change_currency'), chaincode)
 

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
         'chainkey_gui.qt.__init__',
         'chainkey_gui.qt.amountedit',
         'chainkey_gui.qt.console',
+        'chainkey_gui.qt.currency_dialog',
         'chainkey_gui.qt.history_widget',
         'chainkey_gui.qt.icons_rc',
         'chainkey_gui.qt.installwizard',


### PR DESCRIPTION
Separate Change Currency window from the rest of Main Window. Add an option (False by default) to be verbose.

If verbose is True, 
- whether the chain is initialized
- whether the chain has PoW verification
- the number of default servers

will be shown in the Change Currency window. Otherwise, only the first column (whether the chain has been initialized) will be shown.
