### PR TITLE
Remove dependency link for coinhash

### DIFF
--- a/encompass
+++ b/encompass
@@ -67,6 +67,7 @@ try:
     import hid
     import mnemonic
     import google.protobuf
+    import coinhash
     import trezorlib
     from trezorlib import client                                                
     from trezorlib.client import types, proto, BaseClient, ProtocolMixin

--- a/setup.py
+++ b/setup.py
@@ -76,11 +76,10 @@ setup(
 	'tlslite==0.4.8',
 	'dnspython',
 	'trezor==0.6.3',
-        'coinhash==1.1'
+        'coinhash==1.1.2'
     ],
     dependency_links=[
-        "git+https://github.com/mazaclub/python-trezor#egg=trezor",
-        "git+https://github.com/kefkius/coinhash#egg=coinhash-1.1"
+        "git+https://github.com/mazaclub/python-trezor#egg=trezor"
     ],
     package_dir={
         'chainkey': 'lib',


### PR DESCRIPTION
Coinhash is now on PyPI.
