### PR TITLE
Add reorg handling method to base CryptoCur class

### DIFF
--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -214,16 +214,10 @@ class Blockchain(threading.Thread):
             prev_hash = self.hash_header(previous_header)
             if prev_hash != header.get('prev_block_hash'):
                 print_error("reorg")
-                # Call reorg_handler if it exists
-                try:
-                    self.active_chain.reorg_handler(self.local_height)
-                    self.set_local_height()
-                    return None
-                except AttributeError:
-                    self.request_header(interface, height - 1, queue)
-                    requested_header = True
-                    continue
-
+                # Call reorg_handler
+                self.active_chain.reorg_handler(self.local_height)
+                self.set_local_height()
+                return None
             else:
                 # the chain is complete
                 return chain

--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -95,6 +95,15 @@ class CryptoCur(object):
                     l.append( self.__class__ )
                 chainhooks[k] = l
 
+    # Called on chain reorg. Go back by COINBASE_MATURITY.
+    def reorg_handler(self, local_height):
+        name = self.path()
+        if os.path.exists(name):
+            f = open(name, 'rb+')
+            f.seek((local_height*80) - (self.COINBASE_MATURITY*80))
+            f.truncate()
+            f.close()
+
     # Tell us where our blockchain_headers file is
     def set_headers_path(self, path):
         self.headers_path = path

--- a/lib/chains/mazacoin.py
+++ b/lib/chains/mazacoin.py
@@ -39,15 +39,6 @@ class Mazacoin(CryptoCur):
         'tate.cryptoadhd.com':DEFAULT_PORTS,
     }
 
-    # Used on chain reorg
-    def reorg_handler(self, local_height):
-        name = self.path()
-        if os.path.exists(name):
-            f = open(name,'rb+')
-            f.seek((local_height*80) - (self.COINBASE_MATURITY * 80))
-            f.truncate()
-            f.close()
-
     def verify_chain(self, chain):
 
         first_header = chain[0]


### PR DESCRIPTION
On reorg, by default all chains will go back by COINBASE_MATURITY headers.
