### PR TITLE
Add utility functions bits_to_target and target_to_bits to cryptocur.py

### DIFF
--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -14,6 +14,33 @@ def int_to_hex(i, length=1):
     s = "0"*(2*length - len(s)) + s
     return rev_hex(s)
 
+def bits_to_target(self, bits):
+    """Convert a compact representation to a hex target."""
+    MM = 256*256*256
+    a = bits%MM
+    if a < 0x8000:
+        a *= 256
+    target = (a) * pow(2, 8 * (bits/MM - 3))
+    return target
+
+def target_to_bits(self, target):
+    """Convert a target to compact representation."""
+    MM = 256*256*256
+    c = ("%064X"%target)[2:]
+    i = 31
+    while c[0:2]=="00":
+        c = c[2:]
+        i -= 1
+
+    c = int('0x'+c[0:6],16)
+    if c >= 0x800000:
+        c /= 256
+        i += 1
+
+    new_bits = c + MM * i
+    return new_bits
+
+
 # Chain hook system
 #
 # This allows the active blockchain to hook into arbitrary functions

--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -14,7 +14,7 @@ def int_to_hex(i, length=1):
     s = "0"*(2*length - len(s)) + s
     return rev_hex(s)
 
-def bits_to_target(self, bits):
+def bits_to_target(bits):
     """Convert a compact representation to a hex target."""
     MM = 256*256*256
     a = bits%MM
@@ -23,7 +23,7 @@ def bits_to_target(self, bits):
     target = (a) * pow(2, 8 * (bits/MM - 3))
     return target
 
-def target_to_bits(self, target):
+def target_to_bits(target):
     """Convert a target to compact representation."""
     MM = 256*256*256
     c = ("%064X"%target)[2:]

--- a/lib/chains/feathercoin.py
+++ b/lib/chains/feathercoin.py
@@ -1,5 +1,5 @@
 '''Chain-specific Feathercoin code'''
-from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex
+from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex, bits_to_target, target_to_bits
 import os
 
 from coinhash import SHA256dHash, NeoscryptHash, ScryptHash
@@ -9,31 +9,6 @@ fork_one = 33000
 fork_two = 87948
 fork_three = 204639
 fork_four = 432000
-
-def bits_to_target(bits):
-    MM = 256*256*256
-    a = bits%MM
-    if a < 0x8000:
-        a *= 256
-    target = (a) * pow(2, 8 * (bits/MM - 3))
-    return target
-
-def target_to_bits(target):
-    MM = 256*256*256
-    c = ("%064X"%target)[2:]
-    i = 31
-    while c[0:2]=="00":
-        c = c[2:]
-        i -= 1
-
-    c = int('0x'+c[0:6],16)
-    if c >= 0x800000:
-        c /= 256
-        i += 1
-
-    new_bits = c + MM * i
-    return new_bits
-
 
 class Feathercoin(CryptoCur):
     PoW = True

--- a/lib/chains/groestlcoin.py
+++ b/lib/chains/groestlcoin.py
@@ -1,4 +1,4 @@
-from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex
+from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex, bits_to_target, target_to_bits
 import os
 
 import coinhash
@@ -121,30 +121,6 @@ class Groestlcoin(CryptoCur):
         h = f.write(data)
         f.close()
 
-    def bits_to_target(self, bits):
-        MM = 256*256*256
-        a = bits%MM
-        if a < 0x8000:
-            a *= 256
-        target = (a) * pow(2, 8 * (bits/MM - 3))
-        return target
-
-    def target_to_bits(self, target):
-        MM = 256*256*256
-        c = ("%064X"%target)[2:]
-        i = 31
-        while c[0:2]=="00":
-            c = c[2:]
-            i -= 1
-
-        c = int('0x'+c[0:6],16)
-        if c >= 0x800000:
-            c /= 256
-            i += 1
-
-        new_bits = c + MM * i
-        return new_bits
-
 
     def get_target_dgw3(self, block_height, chain=None):
         if chain is None:
@@ -178,9 +154,9 @@ class Groestlcoin(CryptoCur):
 
             if CountBlocks <= PastBlocksMin:
                 if CountBlocks == 1:
-                    PastDifficultyAverage = self.bits_to_target(BlockReading.get('bits'))
+                    PastDifficultyAverage = bits_to_target(BlockReading.get('bits'))
                 else:
-                    bnNum = self.bits_to_target(BlockReading.get('bits'))
+                    bnNum = bits_to_target(BlockReading.get('bits'))
                     PastDifficultyAverage = ((PastDifficultyAveragePrev * CountBlocks)+(bnNum)) / (CountBlocks + 1)
                 PastDifficultyAveragePrev = PastDifficultyAverage
 
@@ -206,7 +182,7 @@ class Groestlcoin(CryptoCur):
         bnNew /= nTargetTimespan
         bnNew = min(bnNew, max_target)
 
-        new_bits = self.target_to_bits(bnNew)
+        new_bits = target_to_bits(bnNew)
         return new_bits, bnNew
 
     def get_target(self, block_height, chain=None):

--- a/lib/chains/mazacoin.py
+++ b/lib/chains/mazacoin.py
@@ -1,5 +1,5 @@
 '''Chain-specific Mazacoin code'''
-from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex
+from cryptocur import CryptoCur, hash_encode, hash_decode, rev_hex, int_to_hex, bits_to_target, target_to_bits
 import os
 
 from coinhash import SHA256dHash
@@ -105,32 +105,6 @@ class Mazacoin(CryptoCur):
         f.seek(height*80)
         h = f.write(data)
         f.close()
-
-    def bits_to_target(self, bits):
-        MM = 256*256*256
-        a = bits%MM
-        if a < 0x8000:
-            a *= 256
-        target = (a) * pow(2, 8 * (bits/MM - 3))
-        return target
-
-    def target_to_bits(self, target):
-        MM = 256*256*256
-        c = ("%064X"%target)[2:]
-        i = 31
-        while c[0:2]=="00":
-            c = c[2:]
-            i -= 1
-
-        c = int('0x'+c[0:6],16)
-        if c >= 0x800000:
-            c /= 256
-            i += 1
-
-        new_bits = c + MM * i
-        return new_bits
-
-
 
     def get_target_v1(self, block_height, chain=None):
         # params
@@ -239,9 +213,9 @@ class Mazacoin(CryptoCur):
 
             if CountBlocks <= PastBlocksMin:
                 if CountBlocks == 1:
-                    PastDifficultyAverage = self.bits_to_target(BlockReading.get('bits'))
+                    PastDifficultyAverage = bits_to_target(BlockReading.get('bits'))
                 else:
-                    bnNum = self.bits_to_target(BlockReading.get('bits'))
+                    bnNum = bits_to_target(BlockReading.get('bits'))
                     PastDifficultyAverage = ((PastDifficultyAveragePrev * CountBlocks)+(bnNum)) / (CountBlocks + 1)
                 PastDifficultyAveragePrev = PastDifficultyAverage
 
@@ -268,7 +242,7 @@ class Mazacoin(CryptoCur):
 
         bnNew = min(bnNew, max_target)
 
-        new_bits = self.target_to_bits(bnNew)
+        new_bits = target_to_bits(bnNew)
         return new_bits, bnNew
 
     def get_target(self, block_height, chain=None):


### PR DESCRIPTION
Move some functions for easy re-use by chainkey modules.
