### PR TITLE
Provide generic verify_chunk() and verify_chain() implementations

### DIFF
--- a/lib/chains/README.md
+++ b/lib/chains/README.md
@@ -64,7 +64,7 @@ Lastly, after the currency class definition, it is required to define a variable
 All functions for verifying headers are required in a chainkey module. Most importantly, `get_target()`, `verify_chain()`, and `verify_chunk()`, but also any functions they rely on, including `header_to_string()`, `header_from_string()`, `hash_header()`, `save_chunk()`, `save_header()`, and `read_header()`.
 
 The base class CryptoCur implements some of these functions, since they're unlikely to differ from blockchain to blockchain. They can be re-implemented in a chainkey module's class if necessary.
-The functions CryptoCur implements are: `header_to_string()`, `header_from_string()`, `save_chunk()`, `save_header()`, and `read_header()`.
+The functions CryptoCur implements are: `verify_chain()`, `verify_chunk()`, `header_to_string()`, `header_from_string()`, `save_chunk()`, `save_header()`, and `read_header()`.
 
 Note that commonly in Electrum forks, the functions `save_chunk()` and `save_header()` make a call to a function `set_local_height()`.
 This call must be removed in the chainkey module, as `set_local_height()` is called elsewhere. Also note that any calls to `print_error()` may be removed, as importing that function is not required.

--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -140,11 +140,74 @@ class CryptoCur(object):
 
     # Called from blockchain.py when a chain of headers (arbitrary number of headers that's less than a chunk) needs verification.
     def verify_chain(self, chain):
-        pass
+        first_header = chain[0]
+        prev_header = self.read_header(first_header.get('block_height') - 1)
+        # if we don't verify PoW, just check that headers connect by previous_hash
+        if not self.PoW:
+            for header in chain:
+                prev_hash = self.hash_header(prev_header)
+                try:
+                    assert prev_hash == header.get('prev_block_hash')
+                except Exception:
+                    return False
+            return True
+        for header in chain:
+            height = header.get('block_height')
+
+            prev_hash = self.hash_header(prev_header)
+            bits, target = self.get_target(height/self.chunk_size, chain)
+            _hash = self.hash_header(header)
+            try:
+                assert prev_hash == header.get('prev_block_hash')
+                assert bits == header.get('bits')
+                assert int('0x'+_hash,16) < target
+            except Exception:
+                return False
+
+            prev_header = header
+
+        return True
 
     # Called from blockchain.py when a chunk of headers needs verification.
     def verify_chunk(self, index, hexdata):
-        pass
+        data = hexdata.decode('hex')
+        height = index*self.chunk_size
+        num = len(data)/80
+
+        if index == 0:
+            previous_hash = ("0"*64)
+        else:
+            prev_header = self.read_header(index*self.chunk_size-1)
+            if prev_header is None: raise
+            previous_hash = self.hash_header(prev_header)
+
+        # if we don't verify PoW, just check that headers connect by previous_hash
+        if not self.PoW:
+            for i in range(num):
+                raw_header = data[i*80:(i+1)*80]
+                header = self.header_from_string(raw_header)
+                _hash = self.hash_header(header)
+                assert previous_hash == header.get('prev_block_hash')
+                previous_header = header
+                previous_hash = _hash
+            self.save_chunk(index, data)
+            return
+
+        bits, target = self.get_target(index)
+
+        for i in range(num):
+            height = index*self.chunk_size + i
+            raw_header = data[i*80:(i+1)*80]
+            header = self.header_from_string(raw_header)
+            _hash = self.hash_header(header)
+            assert previous_hash == header.get('prev_block_hash')
+            assert bits == header.get('bits')
+            assert int('0x'+_hash,16) < target
+
+            previous_header = header
+            previous_hash = _hash
+
+        self.save_chunk(index, data)
 
     # Most common header format. Reimplement in a derived class if header format differs.
     def header_to_string(self, res):


### PR DESCRIPTION
Should not have to re-implement them in most chains.
