### PR TITLE
Signing and Verifying on All Chains

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -38,7 +38,7 @@ import icons_rc
 from chainkey.util import format_satoshis
 from chainkey import Transaction
 from chainkey import mnemonic
-from chainkey import util, bitcoin, base58, commands, Interface, Wallet
+from chainkey import util, bitcoin, eckey, base58, commands, Interface, Wallet
 from chainkey import SimpleConfig, Wallet, WalletStorage
 from chainkey import Imported_Wallet
 import chainkey.chainparams
@@ -2092,7 +2092,7 @@ class ElectrumWindow(QMainWindow):
     def do_verify(self, address, message, signature):
         message = unicode(message.toPlainText())
         message = message.encode('utf-8')
-        if bitcoin.verify_message(address.text(), str(signature.toPlainText()), message):
+        if eckey.verify_message(address.text(), str(signature.toPlainText()), message):
             self.show_message(_("Signature verified"))
         else:
             self.show_message(_("Error: wrong signature"))
@@ -2152,7 +2152,7 @@ class ElectrumWindow(QMainWindow):
         message = unicode(message_e.toPlainText())
         message = message.encode('utf-8')
         try:
-            encrypted = bitcoin.encrypt_message(message, str(pubkey_e.text()))
+            encrypted = eckey.encrypt_message(message, str(pubkey_e.text()))
             encrypted_e.setText(encrypted)
         except BaseException as e:
             traceback.print_exc(file=sys.stdout)

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -156,30 +156,20 @@ def ASecretToSecret(key, addrtype=128):
     return base58.ASecretToSecret(key, addrtype)
 
 def regenerate_key(sec, addrtype=128):
-    b = ASecretToSecret(sec, addrtype)
-    if not b:
-        return False
-    b = b[0:32]
-    return EC_KEY(b)
+    """Deprecated."""
+    return eckey.regenerate_key(sec, addrtype)
 
 def is_compressed(sec, addrtype=128):
     """Deprecated."""
     return base58.is_compressed(sec, addrtype)
 
 def public_key_from_private_key(sec, addrtype=128):
-    """Gets the public key of a WIF private key."""
-    # rebuild public key from private key, compressed or uncompressed
-    pkey = regenerate_key(sec, addrtype)
-    assert pkey
-    compressed = is_compressed(sec, addrtype)
-    public_key = GetPubKey(pkey.pubkey, compressed)
-    return public_key.encode('hex')
+    """Deprecated."""
+    return eckey.public_key_from_private_key(sec, addrtype)
 
 def address_from_private_key(sec, addrtype=0, wif_version=128):
-    """Gets the address for a WIF private key."""
-    public_key = public_key_from_private_key(sec, wif_version)
-    address = public_key_to_bc_address(public_key.decode('hex'), addrtype)
-    return address
+    """Deprecated."""
+    return eckey.address_from_private_key(sec, addrtype, wif_version)
 
 def is_valid(addr, active_chain=None):
     """Deprecated."""

--- a/lib/eckey.py
+++ b/lib/eckey.py
@@ -14,6 +14,7 @@ except ImportError:
     sys.exit("Error: AES does not seem to be installed. Try 'sudo pip install slowaes'")
 
 from util_coin import var_int, Hash
+import base58
 from base58 import bc_address_to_hash_160, public_key_to_bc_address
 
 # AES encryption
@@ -76,6 +77,29 @@ def pw_decode(s, password):
 
 
 ################# code from pywallet ######################
+def regenerate_key(sec, addrtype=128):
+    """Gets the EC Key represented by a WIF key."""
+    b = base58.ASecretToSecret(sec, addrtype)
+    if not b:
+        return False
+    b = b[0:32]
+    return EC_KEY(b)
+
+def public_key_from_private_key(sec, addrtype=128):
+    """Gets the public key of a WIF private key."""
+    # rebuild public key from private key, compressed or uncompressed
+    pkey = regenerate_key(sec, addrtype)
+    assert pkey
+    compressed = base58.is_compressed(sec, addrtype)
+    public_key = GetPubKey(pkey.pubkey, compressed)
+    return public_key.encode('hex')
+
+def address_from_private_key(sec, addrtype=0, wif_version=128):
+    """Gets the address for a WIF private key."""
+    public_key = public_key_from_private_key(sec, wif_version)
+    address = public_key_to_bc_address(public_key.decode('hex'), addrtype)
+    return address
+
 # pywallet openssl private key implementation
 
 def i2d_ECPrivateKey(pkey, compressed=False):

--- a/lib/eckey.py
+++ b/lib/eckey.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     sys.exit("Error: AES does not seem to be installed. Try 'sudo pip install slowaes'")
 
+from util import print_error
 from util_coin import var_int, Hash
 import base58
 from base58 import bc_address_to_hash_160, public_key_to_bc_address

--- a/lib/eckey.py
+++ b/lib/eckey.py
@@ -14,7 +14,7 @@ except ImportError:
     sys.exit("Error: AES does not seem to be installed. Try 'sudo pip install slowaes'")
 
 from util_coin import var_int, Hash
-from base58 import public_key_to_bc_address
+from base58 import bc_address_to_hash_160, public_key_to_bc_address
 
 # AES encryption
 EncodeAES = lambda secret, s: base64.b64encode(aes.encryptData(secret,s))
@@ -299,7 +299,8 @@ class EC_KEY(object):
         public_key.verify_digest( sig[1:], h, sigdecode = ecdsa.util.sigdecode_string)
 
         # check that we get the original signing address
-        addr = public_key_to_bc_address( point_to_ser(public_key.pubkey.point, compressed) )
+        addrtype = bc_address_to_hash_160(address)[0]
+        addr = public_key_to_bc_address( point_to_ser(public_key.pubkey.point, compressed), addrtype )
         if address != addr:
             raise Exception("Bad signature")
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -424,7 +424,7 @@ class Abstract_Wallet(object):
         assert len(keys) == 1
         sec = keys[0]
         key = regenerate_key(sec, self.active_chain.wif_version)
-        compressed = is_compressed(sec)
+        compressed = is_compressed(sec, addrtype=self.active_chain.wif_version)
         return key.sign_message(message, compressed, address)
 
     def decrypt_message(self, pubkey, message, password):


### PR DESCRIPTION
All chains can now sign and verify messages. The chain's `coin_name` attribute is used in the message magic bytes.
