### PR TITLE
Option to Hide Chains

### DIFF
--- a/data/themes/Terminal/style.css
+++ b/data/themes/Terminal/style.css
@@ -1,4 +1,4 @@
-QDialog, QStatusBar, #plugins_area,
+QDialog, QStatusBar, #plugins_area, #chains_area,
 #main_window, #send_tab, #receive_tab, #console_tab
 {
   background-color: #333;

--- a/gui/qt/currency_dialog.py
+++ b/gui/qt/currency_dialog.py
@@ -10,6 +10,7 @@ from util import HelpButton, ok_cancel_buttons
 
 import functools
 import operator
+import copy
 
 class FavoriteCurrenciesDialog(QDialog):
     def __init__(self, parent):
@@ -17,7 +18,7 @@ class FavoriteCurrenciesDialog(QDialog):
         self.parent = parent
         self.setWindowTitle(_('Favorite Coins'))
         known_chains = chainparams.known_chain_codes
-        self.favorites = self.parent.config.get_above_chain('favorite_chains', [])
+        self.favorites = copy.deepcopy(self.parent.config.get_above_chain('favorite_chains', []))
         # sanity check, just in case. Main window should have already done this
         if len(self.favorites) > 3: self.favorites = self.favorites[:3]
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -47,7 +47,7 @@ from amountedit import AmountEdit, BTCAmountEdit, MyLineEdit
 from network_dialog import NetworkDialog
 from qrcodewidget import QRCodeWidget, QRDialog
 from qrtextedit import ScanQRTextEdit, ShowQRTextEdit
-from currency_dialog import ChangeCurrencyDialog, FavoriteCurrenciesDialog
+from currency_dialog import ChangeCurrencyDialog, FavoriteCurrenciesDialog, HideCurrenciesDialog
 import style
 
 from decimal import Decimal
@@ -2748,10 +2748,18 @@ class ElectrumWindow(QMainWindow):
         if not fav_chains_list: fav_chains_list = 'None'
         fav_chains_list = str(fav_chains_list).replace("'", "")
         favs_label = QLabel(_( 'Favorite coins:' + fav_chains_list ))
-        favs_button = QPushButton(_('Change'))
+        favs_button = QPushButton(_('Change Favorites'))
         favs_help = HelpButton(_('Favorite coins appear before others in the currency selection window.'))
         favs_button.clicked.connect(lambda: FavoriteCurrenciesDialog(self).exec_())
         widgets.append((favs_label, favs_button, favs_help))
+
+        hidden_chains_list = self.config.get_above_chain('hide_chains', [])
+        hidden_chains_number = len(hidden_chains_list)
+        hiddens_label = QLabel(_('Hidden coins: ' + str(hidden_chains_number)))
+        hiddens_button = QPushButton(_('Change Hidden Coins'))
+        hiddens_help = HelpButton(_('Hidden coins do not appear in the currency selection window.'))
+        hiddens_button.clicked.connect(lambda: HideCurrenciesDialog(self).exec_())
+        widgets.append((hiddens_label, hiddens_button, hiddens_help))
 
         nz_label = QLabel(_('Zeros after decimal point') + ':')
         nz_help = HelpButton(_('Number of zeros displayed after the decimal point. For example, if this is set to 2, "1." will be displayed as "1.00"'))


### PR DESCRIPTION
User can now select chains to hide from the currency selection dialog. The hide currencies dialog and the favorite coins dialog now use a QScrollArea to contain the checkboxes.
