### PR TITLE
Allow Daemon to switch chains

### DIFF
--- a/encompass
+++ b/encompass
@@ -315,9 +315,18 @@ def run_cmdline(config):
             sys.exit(1)
         network = NetworkProxy(s, config)
         network.start()
+        network_start_time = time.time()
         while network.is_connecting():
             time.sleep(0.1)
-        if not network.is_connected():
+            # special case for downgrading connection from SSL
+            if cmd.name == 'allownossl':
+                break
+            # advise using allownossl
+            if time.time() - network_start_time > 5 and config.get('use_ssl', True):
+                print_msg('\n'.join([ 'Network does not appear to be connecting. If this problem persists,',
+                                    'use the command "encompass allownossl".' ]))
+                sys.exit(1)
+        if not network.is_connected() and cmd.name != 'allownossl':
             print_msg("daemon is not connected")
             sys.exit(1)
         if wallet:

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -29,8 +29,8 @@ from chainkey.chainparams import get_chain_instance
 
 #protocol_names = ['TCP', 'HTTP', 'SSL', 'HTTPS']
 #protocol_letters = 'thsg'
-protocol_names = ['TCP', 'SSL']
-protocol_letters = 'ts'
+#protocol_names = ['TCP', 'SSL']
+#protocol_letters = 'ts'
 
 class NetworkDialog(QDialog):
     def __init__(self, network, config, parent):
@@ -85,16 +85,16 @@ class NetworkDialog(QDialog):
         vbox.addLayout(grid)
 
         # protocol
-        self.server_protocol = QComboBox()
+        self.use_ssl_box = QCheckBox("Use SSL")
         self.server_host = QLineEdit()
         self.server_host.setFixedWidth(200)
         self.server_port = QLineEdit()
         self.server_port.setFixedWidth(60)
-        self.server_protocol.addItems(protocol_names)
-        self.server_protocol.connect(self.server_protocol, SIGNAL('currentIndexChanged(int)'), self.change_protocol)
+        self.use_ssl_box.setChecked(protocol == 's')
+        self.use_ssl_box.stateChanged.connect(self.change_protocol)
 
         grid.addWidget(QLabel(_('Protocol') + ':'), 3, 0)
-        grid.addWidget(self.server_protocol, 3, 1)
+        grid.addWidget(self.use_ssl_box, 3, 1)
 
         # server
         grid.addWidget(QLabel(_('Server') + ':'), 0, 0)
@@ -125,7 +125,7 @@ class NetworkDialog(QDialog):
         grid.addWidget(self.servers_list_widget, 1, 1, 1, 3)
 
         if not config.is_modifiable('server'):
-            for w in [self.server_host, self.server_port, self.server_protocol, self.servers_list_widget]: w.setEnabled(False)
+            for w in [self.server_host, self.server_port, self.use_ssl_box, self.servers_list_widget]: w.setEnabled(False)
 
         def enable_set_server():
             enabled = not self.autocycle_cb.isChecked()
@@ -185,8 +185,8 @@ class NetworkDialog(QDialog):
             self.protocol = protocol
             self.init_servers_list()
 
-    def change_protocol(self, index):
-        p = protocol_letters[index]
+    def change_protocol(self):
+        p = 's' if self.use_ssl_box.isChecked() else 't'
         host = unicode(self.server_host.text())
         pp = self.servers.get(host, self.active_chain.DEFAULT_PORTS)
         if p not in pp.keys():
@@ -217,12 +217,12 @@ class NetworkDialog(QDialog):
 
         self.server_host.setText( host )
         self.server_port.setText( port )
-        self.server_protocol.setCurrentIndex(protocol_letters.index(protocol))
+        self.use_ssl_box.setChecked(protocol == 's')
 
         if not self.servers: return
-        for p in protocol_letters:
-            i = protocol_letters.index(p)
-            j = self.server_protocol.model().index(i,0)
+        #for p in protocol_letters:
+            #i = protocol_letters.index(p)
+            #j = self.server_protocol.model().index(i,0)
             #if p not in pp.keys(): # and self.interface.is_connected:
             #    self.server_protocol.model().setData(j, QVariant(0), Qt.UserRole-1)
             #else:
@@ -236,7 +236,7 @@ class NetworkDialog(QDialog):
 
         host = str( self.server_host.text() )
         port = str( self.server_port.text() )
-        protocol = protocol_letters[self.server_protocol.currentIndex()]
+        protocol = 's' if self.use_ssl_box.isChecked() else 't'
 
         if self.proxy_mode.currentText() != 'NONE':
             proxy = { 'mode':str(self.proxy_mode.currentText()).lower(),
@@ -247,5 +247,6 @@ class NetworkDialog(QDialog):
 
         auto_connect = self.autocycle_cb.isChecked()
 
+        self.config.set_key('use_ssl', self.use_ssl_box.isChecked())
         self.network.set_parameters(host, port, protocol, proxy, auto_connect)
         return True

--- a/gui/qt/network_dialog.py
+++ b/gui/qt/network_dialog.py
@@ -247,6 +247,5 @@ class NetworkDialog(QDialog):
 
         auto_connect = self.autocycle_cb.isChecked()
 
-        self.config.set_key('use_ssl', self.use_ssl_box.isChecked())
         self.network.set_parameters(host, port, protocol, proxy, auto_connect)
         return True

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -589,23 +589,21 @@ class Commands:
 #        """Remove a payment request"""
 #        return self.wallet.remove_payment_request(key, self.config)
 
-    @command('w')
+    @command('')
     def getchain(self):
         """Get the chain that your wallet is currently using."""
-        return self.wallet.active_chain_code
+        return self.config.get_active_chain_code()
 
-    @command('nw')
+    @command('n')
     def setchain(self, chaincode):
         """Set the chain that your wallet is currently using."""
         if not chainparams.is_known_chain(chaincode):
             return 'Invalid chain: "{}"'.format(chaincode)
-        # this results in chainparams.set_active_chain being called
-        success = self.wallet.set_chain(chaincode)
-        if not success:
-            return 'Error: Could not switch to chain {}'.format(chaincode)
-        # network knows to get_active_chain
+        if self.config.get_active_chain_code() == chaincode:
+            return 'Active chain is already {}'.format(chaincode)
+        self.config.set_active_chain_code(chaincode)
         self.network.switch_to_active_chain()
-        return 'Active chain is now {}'.format(self.wallet.active_chain_code)
+        return 'Active chain is now {}'.format(self.config.get_active_chain_code())
 
     @command('')
     def listchains(self):

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -594,12 +594,18 @@ class Commands:
         """Get the chain that your wallet is currently using."""
         return self.wallet.active_chain_code
 
-    @command('w')
+    @command('nw')
     def setchain(self, chaincode):
         """Set the chain that your wallet is currently using."""
         if not chainparams.is_known_chain(chaincode):
             return 'Invalid chain: "{}"'.format(chaincode)
-        self.wallet.set_chain(chaincode)
+        # this results in chainparams.set_active_chain being called
+        success = self.wallet.set_chain(chaincode)
+        if not success:
+            return 'Error: Could not switch to chain {}'.format(chaincode)
+        # network knows to get_active_chain
+        self.network.switch_chains()
+        self.wallet.start_threads(self.network)
         return 'Active chain is now {}'.format(self.wallet.active_chain_code)
 
     @command('')

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -611,7 +611,15 @@ class Commands:
         chains = ["{:8} ({})".format(c.code, c.coin_name) for c in chainparams.known_chains]
         return sorted(chains)
 
-
+    @command('n')
+    def allownossl(self):
+        """Allow non-SSL connections to servers."""
+        host, port, protocol, proxy, auto_connect = self.network.get_parameters()
+        if protocol == 't':
+            return 'Non-SSL connections already allowed'
+        else:
+            self.network.set_parameters(host, port, 't', proxy, auto_connect)
+            return 'Now allowing non-SSL connections'
 
 param_descriptions = {
     'privkey': 'Private key. Type \'?\' to get a prompt.',

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -514,9 +514,9 @@ class Commands:
     @command('n')
     def getheader(self, height, deserialized=False):
         """Retrieve the block header at a given height."""
-        header = self.network.synchronous_get([('blockchain.block.get_header', [height])])[0]
+        header = self.network.get_header(int(height))
         if not header or isinstance(header, unicode):
-            raise BaseException("Unknown block")
+            return 'Error: Unknown block'
         # genesis block
         if header.get('prev_block_hash') is None and header.get('block_height') == 0:
             header['prev_block_hash'] = '0'*64

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -608,7 +608,8 @@ class Commands:
     @command('')
     def listchains(self):
         """List the chains that Encompass supports."""
-        return chainparams.known_chain_codes
+        chains = ["{:8} ({})".format(c.code, c.coin_name) for c in chainparams.known_chains]
+        return sorted(chains)
 
 
 

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -604,8 +604,7 @@ class Commands:
         if not success:
             return 'Error: Could not switch to chain {}'.format(chaincode)
         # network knows to get_active_chain
-        self.network.switch_chains()
-        self.wallet.start_threads(self.network)
+        self.network.switch_to_active_chain()
         return 'Active chain is now {}'.format(self.wallet.active_chain_code)
 
     @command('')

--- a/lib/network.py
+++ b/lib/network.py
@@ -181,13 +181,15 @@ class Network(util.DaemonThread):
         self.start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))
 
-    def switch_chains(self, chain=None):
-        if chain is None:
+    def switch_chains(self, chaincode=None):
+        if chaincode is None:
             chain = chainparams.get_active_chain()
+        else:
+            chain = chainparams.get_chain_instance(chaincode)
         self.active_chain = chain
         if self.config.get_active_chain_code() != self.active_chain.code:
             self.config.set_active_chain_code(self.active_chain.code)
-        print("Switching chains to {}".format(chain.code))
+        print("Network: Switching chains to {}".format(chain.code))
         self.stop_network()
         self.bc_requests.clear()
         self.blockchain = Blockchain(self.config, self, self.active_chain)
@@ -222,7 +224,7 @@ class Network(util.DaemonThread):
         # Start the new network
         self.start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))
-        print("Switched chains to {}".format(chain.code))
+        print("Network: Switched chains to {}".format(chain.code))
 
     def read_recent_servers(self):
         return self.config.get('recent_servers', [])

--- a/lib/network.py
+++ b/lib/network.py
@@ -189,7 +189,7 @@ class Network(util.DaemonThread):
         self.active_chain = chain
         if self.config.get_active_chain_code() != self.active_chain.code:
             self.config.set_active_chain_code(self.active_chain.code)
-        print("Network: Switching chains to {}".format(chain.code))
+        self.print_error('switching chains to {}'.format(chain.code))
         self.stop_network()
         self.bc_requests.clear()
         self.blockchain = Blockchain(self.config, self, self.active_chain)
@@ -224,7 +224,6 @@ class Network(util.DaemonThread):
         # Start the new network
         self.start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))
-        print("Network: Switched chains to {}".format(chain.code))
 
     def read_recent_servers(self):
         return self.config.get('recent_servers', [])

--- a/lib/network.py
+++ b/lib/network.py
@@ -193,6 +193,7 @@ class Network(util.DaemonThread):
         self.stop_network()
         self.bc_requests.clear()
         self.blockchain = Blockchain(self.config, self, self.active_chain)
+        self.queue = Queue.Queue()
 
         self.default_server = self.config.get('server')
         # Sanitize default server
@@ -221,6 +222,7 @@ class Network(util.DaemonThread):
         # unanswered requests
         self.unanswered_requests = {}
 
+        self.blockchain.init()
         # Start the new network
         self.start_network(deserialize_server(self.default_server)[2],
                            deserialize_proxy(self.config.get('proxy')))

--- a/lib/network.py
+++ b/lib/network.py
@@ -19,6 +19,8 @@ from collections import deque
 NODES_RETRY_INTERVAL = 60
 SERVER_RETRY_INTERVAL = 10
 
+def get_protocol_letter(use_ssl = True):
+    return 's' if use_ssl else 't'
 
 def parse_servers(result, active_chain=None):
     """ parse servers list into dict format"""
@@ -134,6 +136,7 @@ class Network(util.DaemonThread):
         if active_chain is None:
             active_chain = chainparams.get_active_chain()
         self.active_chain = active_chain
+        self.use_ssl = config.get('use_ssl', True)
 
         self.num_server = 8 if not self.config.get('oneserver') else 0
         self.blockchain = Blockchain(self.config, self, self.active_chain)
@@ -150,7 +153,7 @@ class Network(util.DaemonThread):
         except:
             self.default_server = None
         if not self.default_server:
-            self.default_server = pick_random_server(active_chain = self.active_chain)
+            self.default_server = pick_random_server(active_chain = self.active_chain, protocol = get_protocol_letter(self.use_ssl))
 
         self.irc_servers = {} # returned by interface (list from irc)
         self.recent_servers = self.read_recent_servers()
@@ -202,7 +205,7 @@ class Network(util.DaemonThread):
         except:
             self.default_server = None
         if not self.default_server:
-            self.default_server = pick_random_server(active_chain = self.active_chain)
+            self.default_server = pick_random_server(active_chain = self.active_chain, protocol = get_protocol_letter(self.use_ssl))
 
         self.irc_servers = {} # returned by interface (list from irc)
         self.recent_servers = self.read_recent_servers()

--- a/lib/network_proxy.py
+++ b/lib/network_proxy.py
@@ -236,6 +236,7 @@ class NetworkProxy(util.DaemonThread):
         server_str = serialize_server(host, port, protocol)
         self.config.set_key('auto_connect', auto_connect, True)
         self.config.set_key("proxy", proxy_str, True)
+        self.config.set_key("use_ssl", protocol == 's', True)
         self.config.set_key("server", server_str, True)
         # abort if changes were not allowed by config
         if self.config.get('server') != server_str or self.config.get('proxy') != proxy_str:

--- a/lib/network_proxy.py
+++ b/lib/network_proxy.py
@@ -83,12 +83,7 @@ class NetworkProxy(util.DaemonThread):
 
             # Not daemon, probably running GUI
             if self.network:
-                self.network.stop()
-                time.sleep(0.3)
-
-                self.pipe = util.QueuePipe()
-                self.network = Network(self.pipe, self.config)
-                self.network.start()
+                self.network.switch_chains()
 
                 for key in ['status','banner','updated','servers','interfaces']:
                     value = self.network.get_status_value(key)

--- a/lib/network_proxy.py
+++ b/lib/network_proxy.py
@@ -133,7 +133,10 @@ class NetworkProxy(util.DaemonThread):
         error = response.get('error')
         if msg_id is not None:
             with self.lock:
-                method, params, callback = self.unanswered_requests.pop(msg_id)
+                try:
+                    method, params, callback = self.unanswered_requests.pop(msg_id)
+                except KeyError:
+                    return
         else:
             method = response.get('method')
             params = response.get('params')

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -82,6 +82,13 @@ class SimpleConfig(object):
         # user config.
         self.user_config = read_user_config_function(self.path)
 
+        # rare case in which there's no config section for the active chain
+        # since this is accounted for in set_active_chain_code, the following accounts for
+        # when the active_chain is set manually in the config fiile.
+        chaincode = self.get_active_chain_code(default=chainparams.get_active_chain().code)
+        if self.get_chain_config(chaincode) is None:
+            self.set_chain_config(chaincode, {})
+
         if not self.dormant: set_config(self)  # Make a singleton instance of 'self'
 
     def init_path(self):

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -85,7 +85,7 @@ class SimpleConfig(object):
         # rare case in which there's no config section for the active chain
         # since this is accounted for in set_active_chain_code, the following accounts for
         # when the active_chain is set manually in the config fiile.
-        chaincode = self.get_active_chain_code(default=chainparams.get_active_chain().code)
+        chaincode = self.get_active_chain_code(default='MZC')
         if self.get_chain_config(chaincode) is None:
             self.set_chain_config(chaincode, {})
 

--- a/lib/tests/test_simple_config.py
+++ b/lib/tests/test_simple_config.py
@@ -152,7 +152,7 @@ class Test_SimpleConfig(unittest.TestCase):
         with open(os.path.join(self.electrum_dir, "config"), "r") as f:
             contents = f.read()
         result = ast.literal_eval(contents)
-        self.assertEqual({"something": "a"}, result)
+        self.assertEqual({"something": "a", "MZC": {}}, result)
 
 
 class TestSystemConfig(unittest.TestCase):

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -244,7 +244,6 @@ class Abstract_Wallet(object):
         result = self.storage.config.set_active_chain_code(chaincode)
         if result == False:
             return False # Invalid chain
-        self.stop_threads()
         self.__init__(self.storage)
         return True
 
@@ -1037,8 +1036,10 @@ class Abstract_Wallet(object):
 
     def stop_threads(self):
         if self.network:
-            self.verifier.stop()
-            self.synchronizer.stop()
+            if self.verifier:
+                self.verifier.stop()
+            if self.synchronizer:
+                self.synchronizer.stop()
 
     def restore(self, cb):
         pass

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -244,7 +244,9 @@ class Abstract_Wallet(object):
         result = self.storage.config.set_active_chain_code(chaincode)
         if result == False:
             return False # Invalid chain
+        self.stop_threads()
         self.__init__(self.storage)
+        return True
 
     def load_transactions(self):
         self.transactions = {}


### PR DESCRIPTION
The `setchain` daemon command now causes the network to switch chains as well.

In the network settings dialog, the ComboBox for protocol has been replaced by a CheckBox with the label "Use SSL".

New daemon command `allownossl` provides a convenient way to disable the requirement for SSL connections to servers.
