### PR TITLE
Remove deprecated function calls, improve GUI Console

### DIFF
--- a/gui/android.py
+++ b/gui/android.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import android
 
 from chainkey import SimpleConfig, Wallet, WalletStorage, format_satoshis, mnemonic_encode, mnemonic_decode
-from chainkey.bitcoin import is_valid
+from chainkey.base58 import is_valid
 from chainkey import util
 from decimal import Decimal
 import datetime, re

--- a/gui/gtk.py
+++ b/gui/gtk.py
@@ -25,7 +25,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GObject, cairo
 from decimal import Decimal
 from chainkey.util import print_error
-from chainkey.bitcoin import is_valid
+from chainkey.base58 import is_valid
 from chainkey import WalletStorage, Wallet
 
 Gdk.threads_init()

--- a/gui/qt/console.py
+++ b/gui/qt/console.py
@@ -23,6 +23,8 @@ class Console(QtGui.QPlainTextEdit):
         self.history = []
         self.namespace = {}
         self.construct = []
+        # this will be changed in updateNamespace()
+        self.general_help = lambda: 'Encompass console'
 
         self.setGeometry(50, 75, 600, 400)
         self.setWordWrapMode(QtGui.QTextOption.WrapAnywhere)
@@ -46,6 +48,22 @@ class Console(QtGui.QPlainTextEdit):
 
 
     def updateNamespace(self, namespace):
+        # special help function
+        general_help = namespace.get('help')
+        if general_help:
+            self.general_help = general_help
+        def help(command_name=None):
+            if command_name:
+                help_str = command_name.__doc__
+            else:
+                help_str = '\n\n'.join([
+                                self.general_help(),
+                                'Use help(<command>) to see the help for a command.'])
+            # We print the string instead of returning it, so that newlines work.
+            if help_str:
+                self.appendPlainText(help_str)
+        namespace['help'] = help
+
         self.namespace.update(namespace)
 
     def showMessage(self, message):

--- a/gui/qt/lite_window.py
+++ b/gui/qt/lite_window.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from decimal import Decimal as D
 from chainkey.util import get_resource_path as rsrc
-from chainkey.bitcoin import is_valid
+from chainkey.base58 import is_valid
 from chainkey.i18n import _
 import decimal
 import json

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1758,7 +1758,7 @@ class ElectrumWindow(QMainWindow):
 
     def create_console_tab(self):
         from console import Console
-        self.console = console = Console()
+        self.console = console = Console(parent=self)
         console.setObjectName("console_tab")
         return console
 

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1774,7 +1774,16 @@ class ElectrumWindow(QMainWindow):
         c = commands.Commands(self.config, self.wallet, self.network, lambda: self.console.set_json(True))
         methods = {}
         def mkfunc(f, method):
-            return lambda *args: apply( f, (method, args, self.password_dialog ))
+            def func_wrapper(*args):
+                return f(method, args, self.password_dialog)
+            # update command docstring so we can use help(command_name)
+            if getattr(c, method, None):
+                docstr = getattr(c, method).__doc__
+            else:
+                docstr = ''
+            func_wrapper.__doc__ = docstr
+            return func_wrapper
+
         for m in dir(c):
             if m[0]=='_' or m in ['network','wallet']: continue
             methods[m] = mkfunc(c._run, m)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -30,7 +30,8 @@ from PyQt4.QtGui import *
 from PyQt4.QtCore import *
 import PyQt4.QtCore as QtCore
 
-from chainkey.bitcoin import MIN_RELAY_TX_FEE, is_valid
+from chainkey.bitcoin import MIN_RELAY_TX_FEE
+from chainkey.base58 import is_valid
 from chainkey.plugins import run_hook
 
 import icons_rc
@@ -895,7 +896,7 @@ class ElectrumWindow(QMainWindow):
 
 
     def receive_at(self, addr):
-        if not bitcoin.is_address(addr):
+        if not base58.is_address(addr):
             return
         self.tabs.setCurrentIndex(2)
         self.receive_address_e.setText(addr)
@@ -1138,7 +1139,7 @@ class ElectrumWindow(QMainWindow):
                 return
             if type == 'op_return':
                 continue
-            if type == 'address' and not bitcoin.is_address(addr):
+            if type == 'address' and not base58.is_address(addr):
                 QMessageBox.warning(self, _('Error'), _('Invalid coin Address'), _('OK'))
                 return
             if amount is None:
@@ -2396,7 +2397,7 @@ class ElectrumWindow(QMainWindow):
         try:
             for position, row in enumerate(csvReader):
                 address = row[0]
-                if not bitcoin.is_address(address):
+                if not base58.is_address(address):
                     errors.append((position, address))
                     continue
                 amount = Decimal(row[1])
@@ -2694,7 +2695,7 @@ class ElectrumWindow(QMainWindow):
 
         def get_address():
             addr = str(address_e.text())
-            if bitcoin.is_address(addr):
+            if base58.is_address(addr):
                 return addr
 
         def get_pk():

--- a/gui/qt/paytoedit.py
+++ b/gui/qt/paytoedit.py
@@ -22,7 +22,7 @@ from qrtextedit import ScanQRTextEdit
 
 import re
 from decimal import Decimal
-from chainkey import bitcoin
+from chainkey import base58
 
 RE_ADDRESS = '[1-9A-HJ-NP-Za-km-z]{26,}'
 RE_ALIAS = '(.*?)\s*\<([1-9A-HJ-NP-Za-km-z]{26,})\>'
@@ -88,7 +88,7 @@ class PayToEdit(ScanQRTextEdit):
         r = line.strip()
         m = re.match('^'+RE_ALIAS+'$', r)
         address = m.group(2) if m else r
-        assert bitcoin.is_address(address)
+        assert base58.is_address(address)
         return address
 
 

--- a/gui/text.py
+++ b/gui/text.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 _ = lambda x:x
 #from i18n import _
 from chainkey.util import format_satoshis, set_verbosity
-from chainkey.bitcoin import is_valid
+from chainkey.base58 import is_valid
 
 from chainkey import Wallet, WalletStorage
 

--- a/lib/account.py
+++ b/lib/account.py
@@ -20,6 +20,7 @@ import util_coin
 import script
 import bitcoin
 from bitcoin import *
+from base58 import public_key_to_bc_address, EncodeBase58Check, DecodeBase58Check
 from i18n import _
 from transaction import is_extended_pubkey
 from util import print_msg
@@ -347,14 +348,14 @@ class BIP32_Account(Account):
         # unsorted
         s = ''.join(map(lambda x: util_coin.int_to_hex(x,2), (for_change,n)))
         xpubs = self.get_master_pubkeys()
-        return map(lambda xpub: 'ff' + bitcoin.DecodeBase58Check(xpub).encode('hex') + s, xpubs)
+        return map(lambda xpub: 'ff' + DecodeBase58Check(xpub).encode('hex') + s, xpubs)
 
     @classmethod
     def parse_xpubkey(self, pubkey):
         assert is_extended_pubkey(pubkey)
         pk = pubkey.decode('hex')
         pk = pk[1:]
-        xkey = bitcoin.EncodeBase58Check(pk[0:78])
+        xkey = EncodeBase58Check(pk[0:78])
         dd = pk[78:]
         s = []
         while dd:

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -57,35 +57,6 @@ def get_max_n(m):
         n -= 1
     return n
 
-
-def rev_hex(s):
-    """Deprecated."""
-    return util_coin.rev_hex(s)
-
-def int_to_hex(i, length=1):
-    """Deprecated."""
-    return util_coin.int_to_hex(i, length)
-
-def op_push(i):
-    """Deprecated."""
-    return util_coin.op_push(i)
-
-def sha256(x):
-    """Deprecated."""
-    return util_coin.sha256(x)
-
-def Hash(x):
-    """Deprecated."""
-    return util_coin.Hash(x)
-
-def hash_encode(x):
-    """Deprecated."""
-    return util_coin.hash_encode(x)
-
-def hash_decode(x):
-    """Deprecated."""
-    return util_coin.hash_decode(x)
-
 hmac_sha_512 = lambda x,y: hmac.new(x, y, hashlib.sha512).digest()
 
 def is_new_seed(x, prefix=version.SEED_BIP44):
@@ -115,89 +86,29 @@ def is_old_seed(seed):
 
 ############ functions from pywallet #####################
 
-def hash_160(public_key):
-    """Deprecated."""
-    return base58.hash_160(public_key)
-
-def public_key_to_bc_address(public_key, addrtype=0):
-    """Deprecated."""
-    return base58.public_key_to_bc_address(public_key, addrtype)
-
-def hash_160_to_bc_address(h160, addrtype = 0):
-    """Deprecated."""
-    return base58.hash_160_to_bc_address(h160, addrtype)
-
-def bc_address_to_hash_160(addr):
-    """Deprecated."""
-    return base58.bc_address_to_hash_160(addr)
-
-def b58encode(v):
-    """Deprecated."""
-    return base58.b58encode(v)
-
-def b58decode(v, length):
-    """Deprecated."""
-    return base58.b58decode(v)
-
-def EncodeBase58Check(vchIn):
-    """Deprecated."""
-    return base58.EncodeBase58Check(vchIn)
-
-def DecodeBase58Check(psz):
-    """Deprecated."""
-    return base58.DecodeBase58Check(psz)
-
-def SecretToASecret(secret, compressed=False, addrtype=128):
-    """Deprecated."""
-    return base58.SecretToASecret(secret, compressed, addrtype)
-
-def ASecretToSecret(key, addrtype=128):
-    """Deprecated."""
-    return base58.ASecretToSecret(key, addrtype)
-
 def regenerate_key(sec, addrtype=128):
-    b = ASecretToSecret(sec, addrtype)
+    b = base58.ASecretToSecret(sec, addrtype)
     if not b:
         return False
     b = b[0:32]
     return EC_KEY(b)
-
-def is_compressed(sec, addrtype=128):
-    """Deprecated."""
-    return base58.is_compressed(sec, addrtype)
 
 def public_key_from_private_key(sec, addrtype=128):
     """Gets the public key of a WIF private key."""
     # rebuild public key from private key, compressed or uncompressed
     pkey = regenerate_key(sec, addrtype)
     assert pkey
-    compressed = is_compressed(sec, addrtype)
+    compressed = base58.is_compressed(sec, addrtype)
     public_key = GetPubKey(pkey.pubkey, compressed)
     return public_key.encode('hex')
 
 def address_from_private_key(sec, addrtype=0, wif_version=128):
     """Gets the address for a WIF private key."""
     public_key = public_key_from_private_key(sec, wif_version)
-    address = public_key_to_bc_address(public_key.decode('hex'), addrtype)
+    address = base58.public_key_to_bc_address(public_key.decode('hex'), addrtype)
     return address
 
-def is_valid(addr, active_chain=None):
-    """Deprecated."""
-    return base58.is_valid(addr, active_chain)
-
-def is_address(addr, active_chain=None):
-    """Deprecated."""
-    return base58.is_address(addr, active_chain)
-
-def is_private_key(key, addrtype=128):
-    """Deprecated."""
-    return base58.is_private_key(key, addrtype)
-
-
 ########### end pywallet functions #######################
-def get_pubkeys_from_secret(secret):
-    """Deprecated."""
-    return eckey.get_pubkeys_from_secret(secret)
 
 ###################################### BIP32 ##############################
 
@@ -279,7 +190,7 @@ def deserialize_xkey(xkey):
 
     """
 
-    xkey = DecodeBase58Check(xkey)
+    xkey = base58.DecodeBase58Check(xkey)
     assert len(xkey) == 78
 
     xkey_header = xkey[0:4].encode('hex')
@@ -320,10 +231,10 @@ def get_xkey_name(xkey, testnet=False):
 
 def xpub_from_xprv(xprv, testnet=False):
     depth, fingerprint, child_number, c, k = deserialize_xkey(xprv)
-    K, cK = get_pubkeys_from_secret(k)
+    K, cK = eckey.get_pubkeys_from_secret(k)
     header_pub, _  = _get_headers(testnet)
     xpub = header_pub.decode('hex') + chr(depth) + fingerprint + child_number + c + cK
-    return EncodeBase58Check(xpub)
+    return base58.EncodeBase58Check(xpub)
 
 
 def bip32_root(seed, testnet=False):
@@ -333,10 +244,10 @@ def bip32_root(seed, testnet=False):
     I = hmac.new("Bitcoin seed", seed, hashlib.sha512).digest()
     master_k = I[0:32]
     master_c = I[32:]
-    K, cK = get_pubkeys_from_secret(master_k)
+    K, cK = eckey.get_pubkeys_from_secret(master_k)
     xprv = (header_priv + "00" + "00000000" + "00000000").decode("hex") + master_c + chr(0) + master_k
     xpub = (header_pub + "00" + "00000000" + "00000000").decode("hex") + master_c + cK
-    return EncodeBase58Check(xprv), EncodeBase58Check(xpub)
+    return base58.EncodeBase58Check(xprv), base58.EncodeBase58Check(xpub)
 
 
 def bip32_private_derivation(xprv, branch, sequence, testnet=False):
@@ -364,13 +275,13 @@ def bip32_private_derivation(xprv, branch, sequence, testnet=False):
         k, c = CKD_priv(k, c, i)
         depth += 1
 
-    _, parent_cK = get_pubkeys_from_secret(parent_k)
-    fingerprint = hash_160(parent_cK)[0:4]
+    _, parent_cK = eckey.get_pubkeys_from_secret(parent_k)
+    fingerprint = base58.hash_160(parent_cK)[0:4]
     child_number = ("%08X"%i).decode('hex')
-    K, cK = get_pubkeys_from_secret(k)
+    K, cK = eckey.get_pubkeys_from_secret(k)
     xprv = header_priv.decode('hex') + chr(depth) + fingerprint + child_number + c + chr(0) + k
     xpub = header_pub.decode('hex') + chr(depth) + fingerprint + child_number + c + cK
-    return EncodeBase58Check(xprv), EncodeBase58Check(xpub)
+    return base58.EncodeBase58Check(xprv), base58.EncodeBase58Check(xpub)
 
 
 def bip32_public_derivation(xpub, branch, sequence, testnet=False):
@@ -398,10 +309,10 @@ def bip32_public_derivation(xpub, branch, sequence, testnet=False):
         cK, c = CKD_pub(cK, c, i)
         depth += 1
 
-    fingerprint = hash_160(parent_cK)[0:4]
+    fingerprint = base58.hash_160(parent_cK)[0:4]
     child_number = ("%08X"%i).decode('hex')
     xpub = header_pub.decode('hex') + chr(depth) + fingerprint + child_number + c + cK
-    return EncodeBase58Check(xpub)
+    return base58.EncodeBase58Check(xpub)
 
 
 def bip32_private_key(sequence, k, chain, addrtype=128):
@@ -419,4 +330,4 @@ def bip32_private_key(sequence, k, chain, addrtype=128):
     """
     for i in sequence:
         k, chain = CKD_priv(k, chain, i)
-    return SecretToASecret(k, True, addrtype)
+    return base58.SecretToASecret(k, True, addrtype)

--- a/lib/chainparams.py
+++ b/lib/chainparams.py
@@ -72,6 +72,7 @@ def set_active_chain(chaincode):
     global active_chain
     active_chain = get_chain_instance(chaincode)
     hashes.set_base58_hash(active_chain.base58_hash)
+    hashes.set_merkle_hash(active_chain.merkle_hash)
     hashes.set_transaction_hash(active_chain.transaction_hash)
 
 def is_known_chain(code):

--- a/lib/chains/cryptocur.py
+++ b/lib/chains/cryptocur.py
@@ -92,6 +92,7 @@ class CryptoCur(object):
     ### Hash Algorithms ###
     base58_hash = coinhash.SHA256dHash
     header_hash = coinhash.SHA256dHash
+    merkle_hash = coinhash.SHA256dHash
     transaction_hash = coinhash.SHA256dHash
 
     # Block explorers {name : URL}

--- a/lib/commands.py
+++ b/lib/commands.py
@@ -28,7 +28,8 @@ from functools import wraps
 import util
 from util import print_msg, format_satoshis, print_stderr
 from util_coin import COIN
-from bitcoin import is_valid, hash_160_to_bc_address, hash_160
+import base58
+from base58 import is_valid, hash_160_to_bc_address, hash_160
 from decimal import Decimal
 import bitcoin
 import script
@@ -420,7 +421,7 @@ class Commands:
             csvReader = csv.reader(csvfile, delimiter=',')
             for row in csvReader:
                 address, amount = row
-                assert bitcoin.is_address(address)
+                assert base58.is_address(address)
                 amount = Decimal(amount)
                 outputs.append((address, amount))
         return outputs

--- a/lib/hashes.py
+++ b/lib/hashes.py
@@ -5,9 +5,11 @@ import coinhash
 # Algorithms
 #
 # base58: Used in address encoding and Base58Check encoding.
+# merkle: Used in hashing merkle trees.
 # transaction: Used to hash transactions.
 hash_algos = {
     'base58': coinhash.SHA256dHash,
+    'merkle': coinhash.SHA256dHash,
     'transaction': coinhash.SHA256dHash,
 }
 
@@ -30,14 +32,23 @@ def set_transaction_hash(hash_algo):
     global hash_algos
     hash_algos['transaction'] = hash_algo
 
+def set_merkle_hash(hash_algo):
+    """Set the global hash algorithm used in merkle tree hashing."""
+    global hash_algos
+    hash_algos['merkle'] = hash_algo
 
 def do_hash(algo, x):
     """Convert the algo from a class method to a coinhash function."""
     algo = getattr(coinhash, algo.__name__)
     return algo(x)
 
+
+
 def base58_hash(x):
     return do_hash(hash_algos['base58'], x)
+
+def merkle_hash(x):
+    return do_hash(hash_algos['merkle'], x)
 
 def transaction_hash(x):
     return do_hash(hash_algos['transaction'], x)

--- a/lib/paymentrequest.py
+++ b/lib/paymentrequest.py
@@ -40,8 +40,8 @@ except ImportError:
     sys.exit("Error: requests does not seem to be installed. Try 'sudo pip install requests'")
 
 
-import bitcoin
 import util
+import util_coin
 import transaction
 import x509
 
@@ -114,7 +114,7 @@ class PaymentRequest:
             self.error = "cannot read"
             return
 
-        self.id = bitcoin.sha256(r)[0:16].encode('hex')
+        self.id = util_coin.sha256(r)[0:16].encode('hex')
         filename = os.path.join(self.dir_path, self.id)
         with open(filename,'w') as f:
             f.write(r)
@@ -134,7 +134,7 @@ class PaymentRequest:
         with open(filename,'r') as f:
             r = f.read()
 
-        assert key == bitcoin.sha256(r)[0:16].encode('hex')
+        assert key == util_coin.sha256(r)[0:16].encode('hex')
         self.id = key
         self.parse(r)
 

--- a/lib/tests/test_bitcoin.py
+++ b/lib/tests/test_bitcoin.py
@@ -3,12 +3,12 @@ import sys
 from ecdsa.util import number_to_string
 
 from lib.bitcoin import (
-    public_key_to_bc_address,
     bip32_root, bip32_public_derivation, bip32_private_derivation,
-    Hash, public_key_from_private_key, address_from_private_key,
-    is_valid, is_private_key, xpub_from_xprv)
-from lib.eckey import (
-    generator_secp256k1, point_to_ser, EC_KEY, pw_encode, pw_decode)
+    public_key_from_private_key, address_from_private_key,
+    xpub_from_xprv)
+from lib.util_coin import Hash
+from lib.base58 import public_key_to_bc_address, is_valid, is_private_key
+from lib.eckey import generator_secp256k1, point_to_ser, EC_KEY, pw_encode, pw_decode
 
 try:
     import ecdsa

--- a/lib/tests/test_chains.py
+++ b/lib/tests/test_chains.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 
 from StringIO import StringIO
-from lib import bitcoin
+from lib import bitcoin, base58
 from lib.bitcoin import bip32_root, bip32_private_derivation
 from lib.wallet import WalletStorage, NewWallet
 from lib import chainparams
@@ -182,7 +182,7 @@ class TestChainsBase58(ChainsBase58Test):
 
     def test_wif_encoding(self):
         active_chain = chainparams.get_active_chain()
-        wif = bitcoin.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
+        wif = base58.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
         self.assertEqual('L3PoHZXjsvP91C8WuyiwzYKgjzthZD2Q39Wzrwfsndov6Cwcu8zX', wif)
 
         addr = bitcoin.address_from_private_key(wif, addrtype = active_chain.p2pkh_version, wif_version = active_chain.wif_version)
@@ -190,7 +190,7 @@ class TestChainsBase58(ChainsBase58Test):
 
         chainparams.set_active_chain('MZC')
         active_chain = chainparams.get_active_chain()
-        wif = bitcoin.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
+        wif = base58.SecretToASecret(self.privkey, compressed=True, addrtype = active_chain.wif_version)
         self.assertEqual('aF4LB486ggLLYsQG1FcgRFQSdiBKhP4BfZKWaYvxvaAF7z6MGkAG', wif)
 
         addr = bitcoin.address_from_private_key(wif, addrtype = active_chain.p2pkh_version, wif_version = active_chain.wif_version)

--- a/lib/tests/test_hashes.py
+++ b/lib/tests/test_hashes.py
@@ -1,7 +1,7 @@
 import unittest
 import coinhash
 
-from lib.bitcoin import rev_hex
+from lib.util_coin import rev_hex
 
 class Test_hashes(unittest.TestCase):
 

--- a/lib/tests/test_multisig.py
+++ b/lib/tests/test_multisig.py
@@ -4,7 +4,9 @@ import sys
 import unittest
 
 from StringIO import StringIO
-from lib.bitcoin import bip32_root, bip32_private_derivation, bip32_public_derivation, xpub_from_xprv, deserialize_xkey, hash_160, hash_160_to_bc_address, int_to_hex, DecodeBase58Check
+from lib.bitcoin import bip32_root, bip32_private_derivation, bip32_public_derivation, xpub_from_xprv, deserialize_xkey
+from lib.util_coin import int_to_hex
+from lib.base58 import DecodeBase58Check, hash_160, hash_160_to_bc_address
 from lib.account import BIP32_Account
 from lib.wallet import WalletStorage, Wallet_2of2, Wallet_MofN
 from lib import chainparams

--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -22,8 +22,9 @@
 
 import bitcoin
 from bitcoin import *
+from base58 import public_key_to_bc_address, hash_160_to_bc_address, bc_address_to_hash_160, hash_160
 from util import print_error
-from util_coin import var_int, int_to_hex, op_push
+from util_coin import var_int, int_to_hex, op_push, hash_encode
 from script import *
 import time
 import chainparams

--- a/lib/util.py
+++ b/lib/util.py
@@ -5,6 +5,8 @@ import threading
 from datetime import datetime
 is_verbose = False
 
+import base58
+
 class MyEncoder(json.JSONEncoder):
     def default(self, obj):
         from transaction import Transaction
@@ -198,7 +200,6 @@ def age(from_date, since_date = None, target_tz=None, include_seconds=False):
 
 def parse_URI(uri, active_chain=None):
     import urlparse
-    import bitcoin
     from decimal import Decimal
     import chainparams
 
@@ -206,7 +207,7 @@ def parse_URI(uri, active_chain=None):
         active_chain = chainparams.get_active_chain()
 
     if ':' not in uri:
-        assert bitcoin.is_address(uri, active_chain)
+        assert base58.is_address(uri, active_chain)
         return uri, None, None, None, None
 
     uri_scheme = active_chain.coin_name.lower()
@@ -214,7 +215,7 @@ def parse_URI(uri, active_chain=None):
     assert u.scheme == uri_scheme
 
     address = u.path
-    valid_address = bitcoin.is_address(address, active_chain)
+    valid_address = base58.is_address(address, active_chain)
 
     pq = urlparse.parse_qs(u.query)
 
@@ -423,7 +424,6 @@ class StoreDict(dict):
             self.save()
 
 
-import bitcoin
 from plugins import run_hook
 
 class Contacts(StoreDict):
@@ -432,7 +432,7 @@ class Contacts(StoreDict):
         StoreDict.__init__(self, config, 'contacts')
 
     def resolve(self, k, nocheck=False):
-        if bitcoin.is_address(k):
+        if base58.is_address(k):
             return {'address':k, 'type':'address'}
         if k in self.keys():
             _type, addr = self[k]

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -19,6 +19,7 @@
 
 import threading, time, Queue, os, sys, shutil
 from util import user_dir, appdata_dir, print_error
+from util_coin import Hash, hash_encode, hash_decode
 from bitcoin import *
 
 

--- a/lib/verifier.py
+++ b/lib/verifier.py
@@ -19,7 +19,8 @@
 
 import threading, time, Queue, os, sys, shutil
 from util import user_dir, appdata_dir, print_error
-from util_coin import Hash, hash_encode, hash_decode
+from util_coin import hash_encode, hash_decode
+import hashes
 from bitcoin import *
 
 
@@ -156,7 +157,7 @@ class TxVerifier(threading.Thread):
         h = hash_decode(target_hash)
         for i in range(len(merkle_s)):
             item = merkle_s[i]
-            h = Hash( hash_decode(item) + h ) if ((pos >> i) & 1) else Hash( h + hash_decode(item) )
+            h = hashes.merkle_hash( hash_decode(item) + h ) if ((pos >> i) & 1) else hashes.merkle_hash( h + hash_decode(item) )
         return hash_encode(h)
 
 

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -34,6 +34,7 @@ from bitcoin import *
 from eckey import pw_encode, pw_decode
 from account import *
 from version import *
+import base58
 
 from transaction import Transaction
 from plugins import run_hook
@@ -1961,7 +1962,7 @@ class Wallet(object):
         if not text:
             return False
         for x in text.split():
-            if not bitcoin.is_address(x):
+            if not base58.is_address(x):
                 return False
         return True
 
@@ -1970,7 +1971,7 @@ class Wallet(object):
         if not text:
             return False
         for x in text.split():
-            if not bitcoin.is_private_key(x, chainparams.get_active_chain().wif_version):
+            if not base58.is_private_key(x, chainparams.get_active_chain().wif_version):
                 return False
         return True
 


### PR DESCRIPTION
Calls to deprecated `bitcoin.py` functions have been removed.

In the Qt `console` tab, the `help()` function now works with a command as an argument.

Using `setchain()` from the console now works - the wallet will switch active chains.
